### PR TITLE
fix(Errors): modify Failura monad formats

### DIFF
--- a/app/services/admin/v1/product_categories/creator.rb
+++ b/app/services/admin/v1/product_categories/creator.rb
@@ -18,7 +18,7 @@ module Admin
           e.failure
         rescue StandardError => e
           Rails.logger.error(e)
-          Failure(:internal_error)
+          Failure({ code: :internal_error })
         end
 
         private

--- a/app/services/admin/v1/product_contents/creator.rb
+++ b/app/services/admin/v1/product_contents/creator.rb
@@ -20,7 +20,7 @@ module Admin
           e.failure
         rescue StandardError => e
           Rails.logger.error(e)
-          Failure(:internal_error)
+          Failure({ code: :internal_error })
         end
 
         private

--- a/spec/services/admin/v1/product_categories/creator_spec.rb
+++ b/spec/services/admin/v1/product_categories/creator_spec.rb
@@ -54,5 +54,21 @@ RSpec.describe Admin::V1::ProductCategories::Creator do
         expect(result.failure[:code]).to eq(:invalid_product_category)
       end
     end
+
+    describe 'when service failes due to unhandled error' do
+      before do
+        allow(ProductCategory).to receive(:new).and_raise(StandardError, 'ERROR MESSAGE')
+
+        creator.call
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns internal_error as failure code' do
+        expect(result.failure[:code]).to eq(:internal_error)
+      end
+    end
   end
 end

--- a/spec/services/admin/v1/product_categories/creator_spec.rb
+++ b/spec/services/admin/v1/product_categories/creator_spec.rb
@@ -58,8 +58,6 @@ RSpec.describe Admin::V1::ProductCategories::Creator do
     describe 'when service failes due to unhandled error' do
       before do
         allow(ProductCategory).to receive(:new).and_raise(StandardError, 'ERROR MESSAGE')
-
-        creator.call
       end
 
       it 'returns a failure' do

--- a/spec/services/admin/v1/product_contents/creator_spec.rb
+++ b/spec/services/admin/v1/product_contents/creator_spec.rb
@@ -154,8 +154,6 @@ RSpec.describe Admin::V1::ProductContents::Creator do
     describe 'when service failes due to unhandled error' do
       before do
         allow(Product).to receive(:find).and_raise(StandardError, 'ERROR MESSAGE')
-
-        creator.call
       end
 
       it 'returns a failure' do

--- a/spec/services/admin/v1/product_contents/creator_spec.rb
+++ b/spec/services/admin/v1/product_contents/creator_spec.rb
@@ -150,5 +150,21 @@ RSpec.describe Admin::V1::ProductContents::Creator do
         expect(creator.product_content.files.count).to eq(2)
       end
     end
+
+    describe 'when service failes due to unhandled error' do
+      before do
+        allow(Product).to receive(:find).and_raise(StandardError, 'ERROR MESSAGE')
+
+        creator.call
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns internal_error as failure code' do
+        expect(result.failure[:code]).to eq(:internal_error)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #61 
Some services are returning a monad `Failure(:internal_error)`  on unhandled failure. It should be changed to `Failure({ code: :internal_error })` because now we are expecting all failure response to be a hash with at least a `code` field.