### PR TITLE
feat(PurchaseCarts): cancel a purchase cart

### DIFF
--- a/app/actions/api/v1/purchase_carts/destroyer.rb
+++ b/app/actions/api/v1/purchase_carts/destroyer.rb
@@ -1,0 +1,35 @@
+module Api
+  module V1
+    module PurchaseCarts
+      class Destroyer
+        include Dry::Monads[:result]
+
+        def initialize(cart_uuid:)
+          self.cart_uuid = cart_uuid
+        end
+
+        def call
+          cancel_cart
+          Success()
+        rescue ServiceError => e
+          e.failure
+        rescue StandardError => e
+          Rails.logger.error(e)
+          Failure({ code: :internal_error })
+        end
+
+        private
+
+        attr_accessor :cart_uuid
+
+        def cancel_cart
+          Purchases::CartCanceler.new(cart_uuid: cart_uuid).call
+        rescue Purchases::CartNotFound => e
+          raise ServiceError, Failure({ code: :cart_not_found, message: e.message })
+        rescue Purchases::InvalidStatusForCancelation => e
+          raise ServiceError, Failure({ code: :invalid_status, message: e.message })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/purchase_carts_controller.rb
+++ b/app/controllers/api/v1/purchase_carts_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     class PurchaseCartsController < BaseController
       PURCHASE_CART_ERROR_CODES = {
+        cart_not_found: 404,
+        invalid_status: 422,
         stock_not_found: 400,
         insufficient_stock: 422,
         invalid_cart_item: 422,
@@ -16,6 +18,12 @@ module Api
         return render_error_from(result) if result.failure?
 
         @purchase_cart = result.value!
+      end
+
+      def destroy
+        destroyer = Api::V1::PurchaseCarts::Destroyer.new(cart_uuid: params[:uuid])
+        result = destroyer.call
+        return render_error_from(result) if result.failure?
       end
 
       private

--- a/app/errors/purchases/invalid_status_for_cancelation.rb
+++ b/app/errors/purchases/invalid_status_for_cancelation.rb
@@ -1,0 +1,12 @@
+module Purchases
+  class InvalidStatusForCancelation < StandardError
+    attr_reader :cart_uuid
+
+    def initialize(cart_uuid)
+      @cart_uuid = cart_uuid
+      message = "Cart with uuid '#{@cart_uuid}' cannot be canceled because current status does not allow it"
+
+      super(message)
+    end
+  end
+end

--- a/app/services/purchases/cart_canceler.rb
+++ b/app/services/purchases/cart_canceler.rb
@@ -1,0 +1,34 @@
+module Purchases
+  class CartCanceler
+    INVALID_STATUSES = [
+      PurchaseCart::PAID
+    ].freeze
+
+    def initialize(cart_uuid:)
+      self.cart_uuid = cart_uuid
+    end
+
+    def call
+      find_cart
+      validate_status
+      update_status
+    end
+
+    private
+
+    attr_accessor :cart_uuid, :cart
+
+    def find_cart
+      self.cart = PurchaseCart.find_by(uuid: cart_uuid)
+      raise CartNotFound, cart_uuid if cart.blank?
+    end
+
+    def validate_status
+      raise InvalidStatusForCancelation, cart_uuid if INVALID_STATUSES.include?(cart.status)
+    end
+
+    def update_status
+      cart.update!(status: PurchaseCart::CANCELED)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
       resources :products, only: %i[index show], param: :slug do
         resources :stocks, only: %i[index], param: :uuid
       end
-      resources :purchase_carts, only: %i[create]
+      resources :purchase_carts, only: %i[create destroy], param: :uuid
     end
   end
 end

--- a/spec/actions/api/v1/purchase_carts/destroyer_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/destroyer_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PurchaseCarts::Destroyer do
+  subject(:destroyer) { described_class.new(cart_uuid: cart_uuid) }
+
+  let(:cart) { create(:purchase_cart) }
+  let(:cart_uuid) { cart.uuid }
+
+  describe '#call' do
+    subject(:result) { destroyer.call }
+
+    let(:cart_canceler) { instance_double(Purchases::CartCanceler, call: true) }
+
+    before do
+      allow(Purchases::CartCanceler).to receive(:new).and_return(cart_canceler)
+
+      destroyer.call
+    end
+
+    it 'succeeds' do
+      expect(result.success?).to eq(true)
+    end
+
+    it 'calls the cart canceler' do
+      expect(cart_canceler).to have_received(:call)
+    end
+
+    describe 'when service failes due to unhandled error' do
+      before do
+        allow(cart_canceler).to receive(:call).and_raise(StandardError, 'ERROR MESSAGE')
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns internal_error as failure code' do
+        expect(result.failure[:code]).to eq(:internal_error)
+      end
+    end
+
+    describe "when cart isn't found" do
+      before do
+        allow(cart_canceler).to receive(:call).and_raise(Purchases::CartNotFound.new(any_args))
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns the right error code' do
+        expect(result.failure[:code]).to eq(:cart_not_found)
+      end
+    end
+
+    describe 'when cart has invalid status' do
+      before do
+        allow(cart_canceler).to receive(:call).and_raise(Purchases::InvalidStatusForCancelation.new(any_args))
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns the right error code' do
+        expect(result.failure[:code]).to eq(:invalid_status)
+      end
+    end
+  end
+end

--- a/spec/services/purchases/cart_canceler_spec.rb
+++ b/spec/services/purchases/cart_canceler_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Purchases::CartCanceler do
+  subject(:canceler) { described_class.new(cart_uuid: cart_uuid) }
+
+  let(:cart) { create(:purchase_cart, status: cart_status) }
+  let(:cart_uuid) { cart.uuid }
+  let(:cart_status) { PurchaseCart::STARTED }
+
+  describe '#call' do
+    describe 'when successful' do
+      before do
+        canceler.call
+      end
+
+      it 'updates the cart status to canceled' do
+        expect(cart.reload.status).to eq(PurchaseCart::CANCELED)
+      end
+    end
+
+    describe 'when cart is not found' do
+      let(:cart_uuid) { '123abc' }
+
+      it 'raises an error' do
+        expect { canceler.call }.to raise_error(Purchases::CartNotFound)
+      end
+    end
+
+    describe 'when cart is already paid' do
+      let(:cart_status) { PurchaseCart::PAID }
+
+      it 'raises an error' do
+        expect { canceler.call }.to raise_error(Purchases::InvalidStatusForCancelation)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #59
New endpoint to "remove" a cart. "remove" means moving the status to canceled, not deleting it from the db.