### PR TITLE
feat(PurchaseCarts): Add and remove cart items

### DIFF
--- a/app/actions/api/v1/cart_items/creator.rb
+++ b/app/actions/api/v1/cart_items/creator.rb
@@ -1,0 +1,56 @@
+module Api
+  module V1
+    module CartItems
+      class Creator
+        include Dry::Monads[:result]
+
+        attr_reader :cart_item
+
+        def initialize(cart_uuid:, item_params:)
+          self.item_params = item_params
+          self.cart_uuid = cart_uuid
+        end
+
+        def call
+          set_cart_item_generator
+          create_item
+
+          Success(cart_item)
+        rescue ServiceError => e
+          e.failure
+        rescue StandardError => e
+          Rails.logger.error(e)
+          Failure({ code: :internal_error })
+        end
+
+        private
+
+        attr_writer :cart_item
+        attr_accessor :cart_uuid, :item_params, :cart_item_generator
+
+        def set_cart_item_generator
+          self.cart_item_generator = Purchases::CartItemGenerator.new(
+            cart_uuid: cart_uuid,
+            stock_uuid: item_params[:stock_uuid],
+            quantity: item_params[:quantity]
+          )
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        def create_item
+          cart_item_generator.call
+          self.cart_item = cart_item_generator.cart_item
+        rescue Purchases::CartNotFound => e
+          raise ServiceError, Failure({ code: :cart_not_found, message: e.message })
+        rescue Purchases::StockNotFound => e
+          raise ServiceError, Failure({ code: :stock_not_found, message: e.message })
+        rescue Purchases::InsufficientStock => e
+          raise ServiceError, Failure({ code: :insufficient_stock, message: e.message })
+        rescue Purchases::InvalidCartItem => e
+          raise ServiceError, Failure({ code: :invalid_cart_item, message: e.message })
+        end
+        # rubocop:enable Metrics/AbcSize
+      end
+    end
+  end
+end

--- a/app/actions/api/v1/cart_items/destroyer.rb
+++ b/app/actions/api/v1/cart_items/destroyer.rb
@@ -1,0 +1,33 @@
+module Api
+  module V1
+    module CartItems
+      class Destroyer
+        include Dry::Monads[:result]
+
+        def initialize(item_uuid:)
+          self.item_uuid = item_uuid
+        end
+
+        def call
+          remove_item
+          Success()
+        rescue ServiceError => e
+          e.failure
+        rescue StandardError => e
+          Rails.logger.error(e)
+          Failure({ code: :internal_error })
+        end
+
+        private
+
+        attr_accessor :item_uuid
+
+        def remove_item
+          Purchases::CartItemRemover.new(item_uuid: item_uuid).call
+        rescue Purchases::CartItemNotFound => e
+          raise ServiceError, Failure({ code: :cart_item_not_found, message: e.message })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/cart_items_controller.rb
+++ b/app/controllers/api/v1/cart_items_controller.rb
@@ -1,0 +1,53 @@
+module Api
+  module V1
+    class CartItemsController < BaseController
+      PURCHASE_CART_ITEM_ERROR_CODES = {
+        cart_not_found: 404,
+        stock_not_found: 400,
+        insufficient_stock: 422,
+        invalid_cart_item: 422,
+        cart_item_not_found: 404
+      }.freeze
+
+      PURCHASE_CART_ITEM_ERROR_MESSAGES = {}.freeze
+
+      def create
+        creator = Api::V1::CartItems::Creator.new(
+          cart_uuid: params[:purchase_cart_uuid],
+          item_params: purchase_cart_item_params
+        )
+        result = creator.call
+        return render_error_from(result) if result.failure?
+
+        @purchase_cart_item = result.value!
+      end
+
+      def destroy
+        destroyer = Api::V1::CartItems::Destroyer.new(item_uuid: params[:uuid])
+        result = destroyer.call
+        return render_error_from(result) if result.failure?
+      end
+
+      private
+
+      def purchase_cart_item_params
+        params.permit(:quantity, :stock_uuid)
+      end
+
+      def error_status_code(error)
+        cart_error_code = PURCHASE_CART_ITEM_ERROR_CODES[error[:code]]
+        return cart_error_code if cart_error_code.present?
+
+        super(error)
+      end
+
+      def error_message(error)
+        cart_error_message = PURCHASE_CART_ITEM_ERROR_MESSAGES[error[:code]] || ''
+        cart_error_message += error[:message] if error[:message].present?
+        return cart_error_message if cart_error_message.present?
+
+        super(error)
+      end
+    end
+  end
+end

--- a/app/errors/purchases/cart_item_not_found.rb
+++ b/app/errors/purchases/cart_item_not_found.rb
@@ -1,0 +1,12 @@
+module Purchases
+  class CartItemNotFound < StandardError
+    attr_reader :item_uuid
+
+    def initialize(item_uuid)
+      @item_uuid = item_uuid
+      message = "Cart Item with uuid '#{@item_uuid}' not found"
+
+      super(message)
+    end
+  end
+end

--- a/app/models/purchase_cart_item.rb
+++ b/app/models/purchase_cart_item.rb
@@ -1,4 +1,6 @@
 class PurchaseCartItem < ApplicationRecord
+  include UuidHandler
+
   belongs_to :stock
   belongs_to :purchase_cart
 

--- a/app/services/purchases/cart_item_remover.rb
+++ b/app/services/purchases/cart_item_remover.rb
@@ -1,0 +1,35 @@
+module Purchases
+  class CartItemRemover
+    def initialize(item_uuid:)
+      self.item_uuid = item_uuid
+    end
+
+    def call
+      find_item
+      find_cart
+      delete_item
+      update_cart_price
+    end
+
+    private
+
+    attr_accessor :item_uuid, :item, :cart
+
+    def find_item
+      self.item = PurchaseCartItem.find_by(uuid: item_uuid)
+      raise CartItemNotFound, item_uuid if item.blank?
+    end
+
+    def find_cart
+      self.cart = item.purchase_cart
+    end
+
+    def delete_item
+      item.destroy!
+    end
+
+    def update_cart_price
+      cart.update_total_price!
+    end
+  end
+end

--- a/app/views/api/v1/cart_items/_purchase_cart_item.json.jbuilder
+++ b/app/views/api/v1/cart_items/_purchase_cart_item.json.jbuilder
@@ -1,0 +1,5 @@
+json.uuid purchase_cart_item.uuid
+json.stock_uuid purchase_cart_item.stock.uuid
+json.quantity purchase_cart_item.quantity
+json.unit_price purchase_cart_item.unit_price
+json.price purchase_cart_item.total_price

--- a/app/views/api/v1/cart_items/create.json.jbuilder
+++ b/app/views/api/v1/cart_items/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'purchase_cart_item', purchase_cart_item: @purchase_cart_item

--- a/app/views/api/v1/purchase_carts/_purchase_cart_item.json.jbuilder
+++ b/app/views/api/v1/purchase_carts/_purchase_cart_item.json.jbuilder
@@ -1,3 +1,4 @@
+json.uuid purchase_cart_item.uuid
 json.stock_uuid purchase_cart_item.stock.uuid
 json.quantity purchase_cart_item.quantity
 json.unit_price purchase_cart_item.unit_price

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,9 @@ Rails.application.routes.draw do
       resources :products, only: %i[index show], param: :slug do
         resources :stocks, only: %i[index], param: :uuid
       end
-      resources :purchase_carts, only: %i[create destroy], param: :uuid
+      resources :purchase_carts, only: %i[create destroy], param: :uuid do
+        resources :cart_items, only: %i[create destroy], param: :uuid
+      end
     end
   end
 end

--- a/db/migrate/20220801045137_add_uuid_to_purchase_cart_items.rb
+++ b/db/migrate/20220801045137_add_uuid_to_purchase_cart_items.rb
@@ -1,0 +1,6 @@
+class AddUuidToPurchaseCartItems < ActiveRecord::Migration[6.1]
+  def change
+    add_column :purchase_cart_items, :uuid, :string, null: false
+    add_index :purchase_cart_items, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_18_215902) do
+ActiveRecord::Schema.define(version: 2022_08_01_045137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,8 +93,10 @@ ActiveRecord::Schema.define(version: 2022_07_18_215902) do
     t.float "unit_price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "uuid", null: false
     t.index ["purchase_cart_id"], name: "index_purchase_cart_items_on_purchase_cart_id"
     t.index ["stock_id"], name: "index_purchase_cart_items_on_stock_id"
+    t.index ["uuid"], name: "index_purchase_cart_items_on_uuid", unique: true
   end
 
   create_table "purchase_carts", force: :cascade do |t|

--- a/spec/actions/api/v1/cart_items/creator_spec.rb
+++ b/spec/actions/api/v1/cart_items/creator_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::CartItems::Creator do
+  subject(:creator) { described_class.new(cart_uuid: cart_uuid, item_params: params) }
+
+  let(:cart_uuid) { create(:purchase_cart).uuid }
+  let(:params) do
+    {
+      stock_uuid: '123abc',
+      quantity: 1
+    }
+  end
+
+  describe '#call' do
+    subject(:result) { creator.call }
+
+    let(:cart_item_generator) { instance_double(Purchases::CartItemGenerator, call: true, cart_item: true) }
+
+    before do
+      allow(Purchases::CartItemGenerator).to receive(:new).and_return(cart_item_generator)
+
+      creator.call
+    end
+
+    it 'succeeds' do
+      expect(result.success?).to eq(true)
+    end
+
+    it 'calls the item generator' do
+      expect(cart_item_generator).to have_received(:call)
+    end
+
+    describe 'when service fails due to unhandled error' do
+      before do
+        allow(cart_item_generator).to receive(:call).and_raise(StandardError, 'ERROR MESSAGE')
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns internal_error as failure code' do
+        expect(result.failure[:code]).to eq(:internal_error)
+      end
+    end
+
+    describe "when stock isn't found" do
+      before do
+        allow(cart_item_generator).to receive(:call).and_raise(Purchases::StockNotFound.new(any_args))
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns the right error code' do
+        expect(result.failure[:code]).to eq(:stock_not_found)
+      end
+    end
+
+    describe 'when there is not enough stock' do
+      before do
+        allow(cart_item_generator).to receive(:call).and_raise(Purchases::InsufficientStock.new(any_args, any_args))
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns the right error code' do
+        expect(result.failure[:code]).to eq(:insufficient_stock)
+      end
+    end
+
+    describe 'when a cart item was invalid' do
+      before do
+        allow(cart_item_generator).to receive(:call).and_raise(Purchases::InvalidCartItem.new([]))
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns the right error code' do
+        expect(result.failure[:code]).to eq(:invalid_cart_item)
+      end
+    end
+
+    describe 'when cart is not found' do
+      before do
+        allow(cart_item_generator).to receive(:call).and_raise(Purchases::CartNotFound.new(any_args))
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns the right error code' do
+        expect(result.failure[:code]).to eq(:cart_not_found)
+      end
+    end
+  end
+end

--- a/spec/actions/api/v1/cart_items/destroyer_spec.rb
+++ b/spec/actions/api/v1/cart_items/destroyer_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::CartItems::Destroyer do
+  subject(:destroyer) { described_class.new(item_uuid: item_uuid) }
+
+  let(:cart_item) { create(:purchase_cart_item) }
+  let(:item_uuid) { cart_item.uuid }
+
+  describe '#call' do
+    subject(:result) { destroyer.call }
+
+    let(:item_remover) { instance_double(Purchases::CartItemRemover, call: true) }
+
+    before do
+      allow(Purchases::CartItemRemover).to receive(:new).and_return(item_remover)
+
+      destroyer.call
+    end
+
+    it 'succeeds' do
+      expect(result.success?).to eq(true)
+    end
+
+    it 'calls the cart item remover' do
+      expect(item_remover).to have_received(:call)
+    end
+
+    describe 'when service fails due to unhandled error' do
+      before do
+        allow(item_remover).to receive(:call).and_raise(StandardError, 'ERROR MESSAGE')
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns internal_error as failure code' do
+        expect(result.failure[:code]).to eq(:internal_error)
+      end
+    end
+
+    describe "when item isn't found" do
+      before do
+        allow(item_remover).to receive(:call).and_raise(Purchases::CartItemNotFound.new(any_args))
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns the right error code' do
+        expect(result.failure[:code]).to eq(:cart_item_not_found)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/cart_items_controller_spec.rb
+++ b/spec/controllers/api/v1/cart_items_controller_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::CartItemsController, type: :controller do
+  render_views
+
+  describe '#create' do
+    let(:payload) do
+      {
+        purchase_cart_uuid: cart.uuid,
+        stock_uuid: '123abc',
+        quantity: 1
+      }
+    end
+    let(:cart) { create(:purchase_cart) }
+    let(:created_item) { create(:purchase_cart_item) }
+    let(:creator_result) do
+      instance_double('Creator Result', success?: true, failure?: false, value!: created_item)
+    end
+    let(:creator) { instance_double(Api::V1::CartItems::Creator, call: creator_result) }
+
+    before do
+      allow(Api::V1::CartItems::Creator).to receive(:new).and_return creator
+
+      request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
+      post :create, format: :json, params: payload
+    end
+
+    it 'calls the collection creator' do
+      expect(creator).to have_received(:call)
+    end
+
+    it 'returns a 200 status' do
+      expect(response.status).to eq 200
+    end
+
+    describe 'when creator fails due to internal error' do
+      let(:creator_result) do
+        instance_double('Creator Result', success?: false, failure?: true, failure: { code: :internal_error })
+      end
+
+      it 'returns a 500 status' do
+        expect(response.status).to eq 500
+      end
+    end
+
+    describe 'when creator fails due to stock not found' do
+      let(:creator_result) do
+        instance_double('Creator Result', success?: false, failure?: true,
+                                          failure: { code: :stock_not_found, message: 'stock not found' })
+      end
+
+      it 'returns a 400 status' do
+        expect(response.status).to eq 400
+      end
+    end
+
+    describe 'when creator fails due to insufficient stock' do
+      let(:creator_result) do
+        instance_double('Creator Result', success?: false, failure?: true,
+                                          failure: { code: :insufficient_stock, message: 'Error' })
+      end
+
+      it 'returns a 422 status' do
+        expect(response.status).to eq 422
+      end
+    end
+
+    describe 'when creator fails due to invalid cart item' do
+      let(:creator_result) do
+        instance_double('Creator Result', success?: false, failure?: true,
+                                          failure: { code: :invalid_cart_item, message: 'Error' })
+      end
+
+      it 'returns a 422 status' do
+        expect(response.status).to eq 422
+      end
+    end
+
+    describe 'when creator fails due to cart not found' do
+      let(:creator_result) do
+        instance_double('Creator Result', success?: false, failure?: true,
+                                          failure: { code: :cart_not_found, message: 'Error' })
+      end
+
+      it 'returns a 404 status' do
+        expect(response.status).to eq 404
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:cart) { create(:purchase_cart) }
+    let(:cart_item) { create(:purchase_cart_item, purchase_cart: cart) }
+    let(:destroyer_result) do
+      instance_double('Destroyer Result', success?: true, failure?: false, value!: nil)
+    end
+    let(:destroyer) { instance_double(Api::V1::CartItems::Destroyer, call: destroyer_result) }
+
+    before do
+      allow(Api::V1::CartItems::Destroyer).to receive(:new).and_return destroyer
+
+      request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
+      delete :destroy, format: :json, params: { uuid: cart_item.uuid, purchase_cart_uuid: cart.uuid }
+    end
+
+    it 'calls the collection destroyer' do
+      expect(destroyer).to have_received(:call)
+    end
+
+    it 'returns a 204 status' do
+      expect(response.status).to eq 204
+    end
+
+    describe 'when destroyer fails due to internal error' do
+      let(:destroyer_result) do
+        instance_double('Destroyer Result', success?: false, failure?: true, failure: { code: :internal_error })
+      end
+
+      it 'returns a 500 status' do
+        expect(response.status).to eq 500
+      end
+    end
+
+    describe 'when destroyer fails due to cart item not found' do
+      let(:destroyer_result) do
+        instance_double('Destroyer Result', success?: false, failure?: true,
+                                            failure: { code: :cart_item_not_found, message: 'cart not found' })
+      end
+
+      it 'returns a 404 status' do
+        expect(response.status).to eq 404
+      end
+    end
+  end
+end

--- a/spec/models/purchase_cart_item_spec.rb
+++ b/spec/models/purchase_cart_item_spec.rb
@@ -21,4 +21,15 @@ RSpec.describe PurchaseCartItem, type: :model do
       expect(cart_item.total_price).to eq(31.0)
     end
   end
+
+  describe 'uuid' do
+    before do
+      cart_item.uuid = nil
+      cart_item.save
+    end
+
+    it 'is generated on creation' do
+      expect(cart_item.uuid).not_to be_nil
+    end
+  end
 end

--- a/spec/services/purchases/cart_item_remover_spec.rb
+++ b/spec/services/purchases/cart_item_remover_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Purchases::CartItemRemover do
+  subject(:remover) { described_class.new(item_uuid: item_uuid) }
+
+  let(:cart) { create(:purchase_cart) }
+  let(:cart_item) { create(:purchase_cart_item, purchase_cart: cart) }
+  let(:item_uuid) { cart_item.uuid }
+
+  describe '#call' do
+    describe 'when successful' do
+      before do
+        remover.call
+      end
+
+      it 'removes the item from the db' do
+        expect(PurchaseCartItem.find_by(uuid: item_uuid)).to be_nil
+      end
+
+      it 'updates the cart price' do
+        expect(cart.reload.total_price).to eq(0)
+      end
+    end
+
+    describe 'when cart ite is not found' do
+      before do
+        allow(PurchaseCartItem).to receive(:find_by).and_return(nil)
+      end
+
+      it 'fails' do
+        expect { remover.call }.to raise_error(Purchases::CartItemNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #69
New endpoints implemented to be able to add or remove items from a purchase cart
```json
// POST /api/v1/purchase_carts/:cart_uuid/cart_items
{
    "stock_uuid": "3176e268-9ceb-47fe-8013-993d0c692475",
    "quantity": 8
}
```

```json
// DELETE /api/v1/purchase_carts/:cart_uuid/cart_items/:item_uuid
```

A uuid field is also added on the `purchase_cart_item` model to deliver it on the responses