### PR TITLE
feat(VerificationCodes): build models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.7'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Email delivery vendor
 gem 'sendgrid-ruby', '~> 6.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    bcrypt (3.1.18)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -289,6 +290,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.4)
   byebug
   dotenv-rails

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,5 @@ class User < ApplicationRecord
   validates :phone, presence: true
 
   has_many :email_communications, as: :target, dependent: :destroy
+  has_many :verification_codes, dependent: :destroy
 end

--- a/app/models/validators/code_status_validator.rb
+++ b/app/models/validators/code_status_validator.rb
@@ -1,0 +1,20 @@
+module Validators
+  class CodeStatusValidator < ActiveModel::Validator
+    def validate(record)
+      @record = record
+
+      record.errors.add :status, 'User already has a code with "started" status' if active_code_present?
+    end
+
+    private
+
+    attr_reader :record
+
+    def active_code_present?
+      user = record.user
+      return if user.blank?
+
+      user.verification_codes.where.not(id: record.id).started.present?
+    end
+  end
+end

--- a/app/models/verification_code.rb
+++ b/app/models/verification_code.rb
@@ -1,0 +1,19 @@
+class VerificationCode < ApplicationRecord
+  belongs_to :user
+  has_secure_password :code
+
+  validates :expires_at, :status, presence: true
+  validates_with Validators::CodeStatusValidator
+
+  STARTED = 'started'.freeze
+  USED = 'used'.freeze
+  EXPIRED = 'expired'.freeze
+
+  STATUS_TYPES = [
+    STARTED,
+    USED,
+    EXPIRED
+  ].freeze
+
+  scope :started, -> { where(status: STARTED) }
+end

--- a/db/migrate/20220807191044_create_verification_codes.rb
+++ b/db/migrate/20220807191044_create_verification_codes.rb
@@ -1,0 +1,13 @@
+class CreateVerificationCodes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :verification_codes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :code_digest, null: false
+      t.string :status, null: false
+      t.datetime :expires_at, null: false
+      t.string :expiration_job_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_06_201721) do
+ActiveRecord::Schema.define(version: 2022_08_07_191044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -170,6 +170,17 @@ ActiveRecord::Schema.define(version: 2022_08_06_201721) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "verification_codes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "code_digest", null: false
+    t.string "status", null: false
+    t.datetime "expires_at", null: false
+    t.string "expiration_job_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_verification_codes_on_user_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "email_communications", "communications"
@@ -182,4 +193,5 @@ ActiveRecord::Schema.define(version: 2022_08_06_201721) do
   add_foreign_key "stock_toppings", "toppings"
   add_foreign_key "stocks", "products"
   add_foreign_key "toppings", "products"
+  add_foreign_key "verification_codes", "users"
 end

--- a/spec/factories/verification_code.rb
+++ b/spec/factories/verification_code.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :verification_code do
+    association :user
+    expires_at { 15.minutes.from_now }
+    status { VerificationCode::STATUS_TYPES.sample }
+    code { format('%06d', rand(0..999_999)) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,5 +12,6 @@ RSpec.describe User, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many(:email_communications) }
+    it { is_expected.to have_many(:verification_codes) }
   end
 end

--- a/spec/models/verification_code_spec.rb
+++ b/spec/models/verification_code_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe VerificationCode, type: :model do
+  subject(:code) { build(:verification_code) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to have_secure_password(:code) }
+    it { is_expected.to validate_presence_of(:expires_at) }
+    it { is_expected.to validate_presence_of(:status) }
+
+    describe 'when the code is started and it belongs to a user with an existing started code' do
+      subject(:code) { build(:verification_code, user: user, status: VerificationCode::STARTED) }
+
+      let(:user) { create(:user) }
+
+      before do
+        create(:verification_code, user: user, status: VerificationCode::STARTED)
+      end
+
+      it 'is not valid' do
+        expect(code.valid?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to #77 

A new VerificationCode model is added. The idea is to save a record on this table every time a new code is generated.
A code digest will be saved on the table, similar to how a password is saved. I'm achieving this behavior thanks to `ActiveModel#has_secure_*` feature https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password