### PR TITLE
chore(ExampleJob): remove it

### DIFF
--- a/app/jobs/example_job.rb
+++ b/app/jobs/example_job.rb
@@ -1,7 +1,0 @@
-class ExampleJob < ApplicationJob
-  queue_as :default
-
-  def perform
-    Rails.logger.info 'Running ExampleJob'
-  end
-end

--- a/spec/jobs/example_job_spec.rb
+++ b/spec/jobs/example_job_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe ExampleJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
Closes #86 
This PR removes a dummy `ExampleJob` class that was there just as placeholder.