### PR TITLE
fix(Emails): remove subject from arguments

### DIFF
--- a/app/jobs/communications/email_sender_job.rb
+++ b/app/jobs/communications/email_sender_job.rb
@@ -4,12 +4,11 @@ module Communications
   class EmailSenderJob < ApplicationJob
     queue_as :default
 
-    def perform(topic:, sender:, recipient:, subject:, template_id:, template_data:, target: nil)
+    def perform(topic:, sender:, recipient:, template_id:, template_data:, target: nil)
       Communications::EmailSender.new(
         topic: topic,
         sender: sender,
         recipient: recipient,
-        subject: subject,
         template_id: template_id,
         template_data: template_data,
         target: target

--- a/app/models/email_communication.rb
+++ b/app/models/email_communication.rb
@@ -4,7 +4,7 @@ class EmailCommunication < ApplicationRecord
   belongs_to :communication
   belongs_to :target, polymorphic: true, optional: true
 
-  validates :sender, :recipient, :subject, :template_id, :template_data, presence: true
+  validates :sender, :recipient, :template_id, :template_data, presence: true
 
   AUTH_SENDER_EMAIL = 'auth@audiophiley.com'
   SENDERS = [

--- a/app/services/authentication/verification_codes/generator.rb
+++ b/app/services/authentication/verification_codes/generator.rb
@@ -45,7 +45,6 @@ module Authentication
           topic: Communication::VERIFICATION_CODE_TOPIC,
           sender: EmailCommunication::AUTH_SENDER_EMAIL,
           recipient: user.email,
-          subject: 'Verification Code',
           template_id: VERIFICATION_CODE_EMAIL_TEMPLATE,
           template_data: {
             user_name: user.name,

--- a/app/services/communications/email_sender.rb
+++ b/app/services/communications/email_sender.rb
@@ -2,11 +2,10 @@ module Communications
   class EmailSender
     attr_reader :communication, :email_communication
 
-    def initialize(topic:, sender:, recipient:, subject:, template_id:, template_data:, target: nil)
+    def initialize(topic:, sender:, recipient:, template_id:, template_data:, target: nil)
       self.topic = topic
       self.sender = sender
       self.recipient = recipient
-      self.subject = subject
       self.template_id = template_id
       self.template_data = template_data
       self.target = target
@@ -27,7 +26,7 @@ module Communications
 
     private
 
-    attr_accessor :topic, :sender, :recipient, :subject, :template_id, :template_data, :personalization, :mail,
+    attr_accessor :topic, :sender, :recipient, :template_id, :template_data, :personalization, :mail,
                   :response, :target
     attr_writer :communication, :email_communication
 
@@ -46,11 +45,8 @@ module Communications
     end
 
     def build_personalization
-      template_data.merge!(subject: subject)
-
       personalization = SendGrid::Personalization.new
       personalization.add_to(SendGrid::Email.new(email: recipient))
-      personalization.subject = subject
       personalization.add_dynamic_template_data(template_data)
 
       self.personalization = personalization
@@ -85,7 +81,6 @@ module Communications
         target: target,
         sender: sender,
         recipient: recipient,
-        subject: subject,
         template_id: template_id,
         template_data: template_data
       )

--- a/db/migrate/20220812053938_remove_subject_from_email_communications.rb
+++ b/db/migrate/20220812053938_remove_subject_from_email_communications.rb
@@ -1,0 +1,9 @@
+class RemoveSubjectFromEmailCommunications < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :email_communications, :subject
+  end
+
+  def down
+    add_column :email_communications, :subject, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_07_191044) do
+ActiveRecord::Schema.define(version: 2022_08_12_053938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,7 +52,6 @@ ActiveRecord::Schema.define(version: 2022_08_07_191044) do
   create_table "email_communications", force: :cascade do |t|
     t.string "sender", null: false
     t.string "recipient", null: false
-    t.string "subject", null: false
     t.string "template_id", null: false
     t.json "template_data"
     t.bigint "communication_id", null: false

--- a/spec/factories/email_communication.rb
+++ b/spec/factories/email_communication.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
 
     sender { EmailCommunication::SENDERS.sample }
     recipient { Faker::Internet.email }
-    subject { Faker::Lorem.sentence }
     template_id { SecureRandom.hex }
     template_data do
       {

--- a/spec/jobs/communications/email_sender_job_spec.rb
+++ b/spec/jobs/communications/email_sender_job_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Communications::EmailSenderJob, type: :job do
   let(:template_data) { { variable: '123' } }
   let(:sender) { EmailCommunication::SENDERS.sample }
   let(:recipient) { Faker::Internet.email }
-  let(:subject_param) { Faker::Lorem.sentence }
   let(:topic) { Communication::TOPICS.sample }
 
   let(:email_sender) { instance_double(Communications::EmailSender, call: true) }
@@ -17,7 +16,6 @@ RSpec.describe Communications::EmailSenderJob, type: :job do
       topic: topic,
       sender: sender,
       recipient: recipient,
-      subject: subject_param,
       template_id: template_id,
       template_data: template_data
     )

--- a/spec/models/email_communication_spec.rb
+++ b/spec/models/email_communication_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe EmailCommunication, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:sender) }
     it { is_expected.to validate_presence_of(:recipient) }
-    it { is_expected.to validate_presence_of(:subject) }
     it { is_expected.to validate_presence_of(:template_id) }
     it { is_expected.to validate_presence_of(:template_data) }
   end

--- a/spec/services/communications/email_sender_spec.rb
+++ b/spec/services/communications/email_sender_spec.rb
@@ -7,7 +7,6 @@ describe Communications::EmailSender do
       template_data: template_data,
       sender: sender,
       recipient: recipient,
-      subject: subject_param,
       topic: topic
     )
   end
@@ -16,7 +15,6 @@ describe Communications::EmailSender do
   let(:template_data) { { variable: '123' } }
   let(:sender) { EmailCommunication::SENDERS.sample }
   let(:recipient) { Faker::Internet.email }
-  let(:subject_param) { Faker::Lorem.sentence }
   let(:topic) { Communication::TOPICS.sample }
 
   describe '#call' do
@@ -25,7 +23,6 @@ describe Communications::EmailSender do
         SendGrid::Personalization,
         {
           add_to: true,
-          "subject=": true,
           add_dynamic_template_data: true
         }
       )


### PR DESCRIPTION
Closes #82
Emails subject is currently being set from here and sent to SendGrid. This should be the responsibility of the SendGrid template and not from this backend, so this PR removes this argument from the service classes, the model and the table in the db