### PR TITLE
feat(PurchaseCarts): associate carts to sessions

### DIFF
--- a/app/actions/api/v1/cart_items/creator.rb
+++ b/app/actions/api/v1/cart_items/creator.rb
@@ -6,9 +6,10 @@ module Api
 
         attr_reader :cart_item
 
-        def initialize(cart_uuid:, item_params:)
+        def initialize(cart_uuid:, item_params:, session:)
           self.item_params = item_params
           self.cart_uuid = cart_uuid
+          self.session = session
         end
 
         def call
@@ -26,13 +27,14 @@ module Api
         private
 
         attr_writer :cart_item
-        attr_accessor :cart_uuid, :item_params, :cart_item_generator
+        attr_accessor :cart_uuid, :item_params, :cart_item_generator, :session
 
         def set_cart_item_generator
           self.cart_item_generator = Purchases::CartItemGenerator.new(
             cart_uuid: cart_uuid,
             stock_uuid: item_params[:stock_uuid],
-            quantity: item_params[:quantity]
+            quantity: item_params[:quantity],
+            session: session
           )
         end
 

--- a/app/actions/api/v1/cart_items/destroyer.rb
+++ b/app/actions/api/v1/cart_items/destroyer.rb
@@ -4,8 +4,9 @@ module Api
       class Destroyer
         include Dry::Monads[:result]
 
-        def initialize(item_uuid:)
+        def initialize(item_uuid:, session:)
           self.item_uuid = item_uuid
+          self.session = session
         end
 
         def call
@@ -20,10 +21,10 @@ module Api
 
         private
 
-        attr_accessor :item_uuid
+        attr_accessor :item_uuid, :session
 
         def remove_item
-          Purchases::CartItemRemover.new(item_uuid: item_uuid).call
+          Purchases::CartItemRemover.new(item_uuid: item_uuid, session: session).call
         rescue Purchases::CartItemNotFound => e
           raise ServiceError, Failure({ code: :cart_item_not_found, message: e.message })
         end

--- a/app/actions/api/v1/purchase_carts/collection_builder.rb
+++ b/app/actions/api/v1/purchase_carts/collection_builder.rb
@@ -1,0 +1,28 @@
+module Api
+  module V1
+    module PurchaseCarts
+      class CollectionBuilder
+        include Dry::Monads[:result]
+
+        def initialize(session:)
+          self.session = session
+        end
+
+        def call
+          self.result = session.purchase_carts
+
+          Success(result)
+        rescue ServiceError => e
+          e.failure
+        rescue StandardError => e
+          Rails.logger.error(e)
+          Failure({ code: :internal_error })
+        end
+
+        private
+
+        attr_accessor :result, :session
+      end
+    end
+  end
+end

--- a/app/actions/api/v1/purchase_carts/creator.rb
+++ b/app/actions/api/v1/purchase_carts/creator.rb
@@ -6,8 +6,9 @@ module Api
 
         attr_reader :params, :purchase_cart
 
-        def initialize(params:)
+        def initialize(params:, session:)
           self.params = params
+          self.session = session
         end
 
         def call
@@ -28,9 +29,10 @@ module Api
         private
 
         attr_writer :params, :purchase_cart
+        attr_accessor :session
 
         def create_cart
-          self.purchase_cart = PurchaseCart.create(
+          self.purchase_cart = session.purchase_carts.create(
             status: PurchaseCart::STARTED,
             total_price: 0
           )

--- a/app/actions/api/v1/purchase_carts/destroyer.rb
+++ b/app/actions/api/v1/purchase_carts/destroyer.rb
@@ -4,8 +4,9 @@ module Api
       class Destroyer
         include Dry::Monads[:result]
 
-        def initialize(cart_uuid:)
+        def initialize(cart_uuid:, session:)
           self.cart_uuid = cart_uuid
+          self.session = session
         end
 
         def call
@@ -20,10 +21,10 @@ module Api
 
         private
 
-        attr_accessor :cart_uuid
+        attr_accessor :cart_uuid, :session
 
         def cancel_cart
-          Purchases::CartCanceler.new(cart_uuid: cart_uuid).call
+          Purchases::CartCanceler.new(cart_uuid: cart_uuid, session: session).call
         rescue Purchases::CartNotFound => e
           raise ServiceError, Failure({ code: :cart_not_found, message: e.message })
         rescue Purchases::InvalidStatusForCancelation => e

--- a/app/actions/api/v1/purchase_carts/finder.rb
+++ b/app/actions/api/v1/purchase_carts/finder.rb
@@ -6,12 +6,13 @@ module Api
 
         attr_reader :cart
 
-        def initialize(cart_uuid:)
+        def initialize(cart_uuid:, session:)
           self.cart_uuid = cart_uuid
+          self.session = session
         end
 
         def call
-          result = PurchaseCart.find_by!(uuid: cart_uuid)
+          result = session.purchase_carts.find_by!(uuid: cart_uuid)
 
           self.cart = result
           Success(result)
@@ -22,7 +23,7 @@ module Api
 
         private
 
-        attr_accessor :cart_uuid
+        attr_accessor :cart_uuid, :session
         attr_writer :cart
       end
     end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class BaseController < Api::BaseController
       include TokenAuth
+      include SessionAuth
 
       before_action :validate_api_key!
 

--- a/app/controllers/api/v1/cart_items_controller.rb
+++ b/app/controllers/api/v1/cart_items_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class CartItemsController < BaseController
       skip_before_action :authenticate_user_by_token!
+      before_action :authenticate_session_by_header!
 
       PURCHASE_CART_ITEM_ERROR_CODES = {
         cart_not_found: 404,
@@ -16,7 +17,8 @@ module Api
       def create
         creator = Api::V1::CartItems::Creator.new(
           cart_uuid: params[:purchase_cart_uuid],
-          item_params: purchase_cart_item_params
+          item_params: purchase_cart_item_params,
+          session: current_session
         )
         result = creator.call
         return render_error_from(result) if result.failure?
@@ -25,7 +27,7 @@ module Api
       end
 
       def destroy
-        destroyer = Api::V1::CartItems::Destroyer.new(item_uuid: params[:uuid])
+        destroyer = Api::V1::CartItems::Destroyer.new(item_uuid: params[:uuid], session: current_session)
         result = destroyer.call
         return render_error_from(result) if result.failure?
       end

--- a/app/controllers/api/v1/purchase_carts_controller.rb
+++ b/app/controllers/api/v1/purchase_carts_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class PurchaseCartsController < BaseController
       skip_before_action :authenticate_user_by_token!
+      before_action :authenticate_session_by_header!
 
       PURCHASE_CART_ERROR_CODES = {
         cart_not_found: 404,
@@ -14,8 +15,16 @@ module Api
 
       PURCHASE_CART_ERROR_MESSAGES = {}.freeze
 
+      def index
+        collection_builder = Api::V1::PurchaseCarts::CollectionBuilder.new(session: current_session)
+        result = collection_builder.call
+        return render_error_from(result) if result.failure?
+
+        @purchase_carts = result.value!
+      end
+
       def create
-        creator = Api::V1::PurchaseCarts::Creator.new(params: purchase_cart_params)
+        creator = Api::V1::PurchaseCarts::Creator.new(params: purchase_cart_params, session: current_session)
         result = creator.call
         return render_error_from(result) if result.failure?
 
@@ -23,13 +32,13 @@ module Api
       end
 
       def destroy
-        destroyer = Api::V1::PurchaseCarts::Destroyer.new(cart_uuid: params[:uuid])
+        destroyer = Api::V1::PurchaseCarts::Destroyer.new(cart_uuid: params[:uuid], session: current_session)
         result = destroyer.call
         return render_error_from(result) if result.failure?
       end
 
       def show
-        finder = Api::V1::PurchaseCarts::Finder.new(cart_uuid: params[:uuid])
+        finder = Api::V1::PurchaseCarts::Finder.new(cart_uuid: params[:uuid], session: current_session)
         result = finder.call
         return render_error_from(result) if result.failure?
 

--- a/app/controllers/concerns/session_auth.rb
+++ b/app/controllers/concerns/session_auth.rb
@@ -1,0 +1,15 @@
+module SessionAuth
+  def authenticate_session_by_header!
+    return head :unauthorized if current_session.blank?
+  end
+
+  def session_uuid
+    @session_uuid ||= request.headers['X-SESSION-ID']
+  end
+
+  def current_session
+    return if session_uuid.blank?
+
+    @current_session ||= Session.find_by(uuid: session_uuid)
+  end
+end

--- a/app/models/purchase_cart.rb
+++ b/app/models/purchase_cart.rb
@@ -13,9 +13,13 @@ class PurchaseCart < ApplicationRecord
 
   validates :total_price, presence: true
   validates :status, presence: true, inclusion: { in: STATUS_TYPES }
+  validates_with Validators::PurchaseCartStatusValidator
 
   has_many :purchase_cart_items, dependent: :destroy
   has_many :purchase_cart_extra_fees, dependent: :destroy
+  belongs_to :session
+
+  scope :started, -> { where(status: STARTED) }
 
   def update_total_price!
     items_price = purchase_cart_items.map(&:total_price).sum

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -2,4 +2,6 @@ class Session < ApplicationRecord
   include UuidHandler
 
   validates :ip_address, presence: true
+
+  has_many :purchase_carts, dependent: :destroy
 end

--- a/app/models/validators/purchase_cart_status_validator.rb
+++ b/app/models/validators/purchase_cart_status_validator.rb
@@ -1,0 +1,20 @@
+module Validators
+  class PurchaseCartStatusValidator < ActiveModel::Validator
+    def validate(record)
+      @record = record
+
+      record.errors.add :status, 'Session already has a started purchase cart' if started_cart_present?
+    end
+
+    private
+
+    attr_reader :record
+
+    def started_cart_present?
+      session = record.session
+      return if session.blank?
+
+      session.purchase_carts.where.not(id: record.id).started.present?
+    end
+  end
+end

--- a/app/services/purchases/cart_canceler.rb
+++ b/app/services/purchases/cart_canceler.rb
@@ -4,8 +4,9 @@ module Purchases
       PurchaseCart::PAID
     ].freeze
 
-    def initialize(cart_uuid:)
+    def initialize(cart_uuid:, session:)
       self.cart_uuid = cart_uuid
+      self.session = session
     end
 
     def call
@@ -16,10 +17,10 @@ module Purchases
 
     private
 
-    attr_accessor :cart_uuid, :cart
+    attr_accessor :cart_uuid, :cart, :session
 
     def find_cart
-      self.cart = PurchaseCart.find_by(uuid: cart_uuid)
+      self.cart = session.purchase_carts.find_by(uuid: cart_uuid)
       raise CartNotFound, cart_uuid if cart.blank?
     end
 

--- a/app/services/purchases/cart_item_generator.rb
+++ b/app/services/purchases/cart_item_generator.rb
@@ -2,11 +2,12 @@ module Purchases
   class CartItemGenerator
     attr_reader :cart_item
 
-    def initialize(stock_uuid:, quantity:, cart: nil, cart_uuid: nil)
+    def initialize(stock_uuid:, quantity:, session: nil, cart: nil, cart_uuid: nil)
       self.cart = cart
       self.cart_uuid = cart_uuid
       self.stock_uuid = stock_uuid
       self.quantity = quantity
+      self.session = session
     end
 
     def call
@@ -19,11 +20,11 @@ module Purchases
 
     private
 
-    attr_accessor :cart_uuid, :stock_uuid, :quantity, :stock, :cart
+    attr_accessor :cart_uuid, :stock_uuid, :quantity, :stock, :cart, :session
     attr_writer :cart_item
 
     def find_cart
-      self.cart = PurchaseCart.find_by(uuid: cart_uuid)
+      self.cart = session.purchase_carts.find_by(uuid: cart_uuid)
       raise CartNotFound, cart_uuid if cart.blank?
     end
 

--- a/app/services/purchases/cart_item_remover.rb
+++ b/app/services/purchases/cart_item_remover.rb
@@ -1,7 +1,8 @@
 module Purchases
   class CartItemRemover
-    def initialize(item_uuid:)
+    def initialize(item_uuid:, session:)
       self.item_uuid = item_uuid
+      self.session = session
     end
 
     def call
@@ -13,7 +14,7 @@ module Purchases
 
     private
 
-    attr_accessor :item_uuid, :item, :cart
+    attr_accessor :item_uuid, :item, :cart, :session
 
     def find_item
       self.item = PurchaseCartItem.find_by(uuid: item_uuid)
@@ -22,6 +23,7 @@ module Purchases
 
     def find_cart
       self.cart = item.purchase_cart
+      raise CartNotFound, cart.uuid if cart.session != session
     end
 
     def delete_item

--- a/app/views/api/v1/purchase_carts/index.json.jbuilder
+++ b/app/views/api/v1/purchase_carts/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @purchase_carts do |cart|
+  json.partial! 'purchase_cart', purchase_cart: cart
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
       resources :products, only: %i[index show], param: :slug do
         resources :stocks, only: %i[index], param: :uuid
       end
-      resources :purchase_carts, only: %i[create destroy show], param: :uuid do
+      resources :purchase_carts, only: %i[index create destroy show], param: :uuid do
         resources :cart_items, only: %i[create destroy], param: :uuid
       end
       namespace :auth do

--- a/db/migrate/20220821191920_add_session_id_to_purchase_carts.rb
+++ b/db/migrate/20220821191920_add_session_id_to_purchase_carts.rb
@@ -1,5 +1,5 @@
 class AddSessionIdToPurchaseCarts < ActiveRecord::Migration[6.1]
   def change
-    add_reference :purchase_carts, :session, foreign_key: true
+    add_reference :purchase_carts, :session, null: false, foreign_key: true
   end
 end

--- a/db/migrate/20220821191920_add_session_id_to_purchase_carts.rb
+++ b/db/migrate/20220821191920_add_session_id_to_purchase_carts.rb
@@ -1,0 +1,5 @@
+class AddSessionIdToPurchaseCarts < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :purchase_carts, :session, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_20_174331) do
+ActiveRecord::Schema.define(version: 2022_08_21_191920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,19 @@ ActiveRecord::Schema.define(version: 2022_08_20_174331) do
     t.index ["target_type", "target_id"], name: "index_email_communications_on_target"
   end
 
+  create_table "locations", force: :cascade do |t|
+    t.string "street_address", null: false
+    t.string "postal_code", null: false
+    t.string "city", null: false
+    t.string "country", null: false
+    t.decimal "longitude"
+    t.decimal "latitude"
+    t.jsonb "raw_geocode"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["longitude", "latitude"], name: "index_locations_on_longitude_and_latitude", unique: true
+  end
+
   create_table "product_categories", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug", null: false
@@ -139,6 +152,8 @@ ActiveRecord::Schema.define(version: 2022_08_20_174331) do
     t.string "uuid", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "session_id"
+    t.index ["session_id"], name: "index_purchase_carts_on_session_id"
     t.index ["uuid"], name: "index_purchase_carts_on_uuid", unique: true
   end
 
@@ -182,6 +197,18 @@ ActiveRecord::Schema.define(version: 2022_08_20_174331) do
     t.index ["product_id"], name: "index_toppings_on_product_id"
   end
 
+  create_table "user_locations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "location_id", null: false
+    t.string "extra_info"
+    t.string "uuid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["location_id"], name: "index_user_locations_on_location_id"
+    t.index ["user_id"], name: "index_user_locations_on_user_id"
+    t.index ["uuid"], name: "index_user_locations_on_uuid", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -212,9 +239,12 @@ ActiveRecord::Schema.define(version: 2022_08_20_174331) do
   add_foreign_key "purchase_cart_extra_fees", "purchase_carts"
   add_foreign_key "purchase_cart_items", "purchase_carts"
   add_foreign_key "purchase_cart_items", "stocks"
+  add_foreign_key "purchase_carts", "sessions"
   add_foreign_key "stock_toppings", "stocks"
   add_foreign_key "stock_toppings", "toppings"
   add_foreign_key "stocks", "products"
   add_foreign_key "toppings", "products"
+  add_foreign_key "user_locations", "locations"
+  add_foreign_key "user_locations", "users"
   add_foreign_key "verification_codes", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,7 +152,7 @@ ActiveRecord::Schema.define(version: 2022_08_21_191920) do
     t.string "uuid", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "session_id"
+    t.bigint "session_id", null: false
     t.index ["session_id"], name: "index_purchase_carts_on_session_id"
     t.index ["uuid"], name: "index_purchase_carts_on_uuid", unique: true
   end

--- a/spec/actions/api/v1/cart_items/creator_spec.rb
+++ b/spec/actions/api/v1/cart_items/creator_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::CartItems::Creator do
-  subject(:creator) { described_class.new(cart_uuid: cart_uuid, item_params: params) }
+  subject(:creator) { described_class.new(cart_uuid: cart_uuid, item_params: params, session: session) }
 
-  let(:cart_uuid) { create(:purchase_cart).uuid }
+  let(:session) { create(:session) }
+  let(:cart_uuid) { create(:purchase_cart, session: session).uuid }
   let(:params) do
     {
       stock_uuid: '123abc',

--- a/spec/actions/api/v1/cart_items/destroyer_spec.rb
+++ b/spec/actions/api/v1/cart_items/destroyer_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::CartItems::Destroyer do
-  subject(:destroyer) { described_class.new(item_uuid: item_uuid) }
+  subject(:destroyer) { described_class.new(item_uuid: item_uuid, session: session) }
 
-  let(:cart_item) { create(:purchase_cart_item) }
+  let(:session) { create(:session) }
+  let(:purchase_cart) { create(:purchase_cart, session: session) }
+  let(:cart_item) { create(:purchase_cart_item, purchase_cart: purchase_cart) }
   let(:item_uuid) { cart_item.uuid }
 
   describe '#call' do

--- a/spec/actions/api/v1/purchase_carts/collection_builder_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/collection_builder_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PurchaseCarts::CollectionBuilder do
+  subject(:builder) { described_class.new(session: session) }
+
+  let(:session) { create(:session) }
+
+  describe '#call' do
+    subject(:result) { builder.call }
+
+    before do
+      create_list(:purchase_cart, 5, session: session, status: [PurchaseCart::PAID, PurchaseCart::CANCELED].sample)
+
+      builder.call
+    end
+
+    it 'succeeds' do
+      expect(result.success?).to eq(true)
+    end
+
+    it 'returns an array with the purchse carts that belong to the session' do
+      expect(result.value!.count).to eq(5)
+    end
+
+    describe 'when service failes due to unhandled error' do
+      before do
+        allow(session).to receive(:purchase_carts).and_raise(StandardError, 'ERROR MESSAGE')
+      end
+
+      it 'returns a failure' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns internal_error as failure code' do
+        expect(result.failure[:code]).to eq(:internal_error)
+      end
+    end
+  end
+end

--- a/spec/actions/api/v1/purchase_carts/destroyer_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/destroyer_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PurchaseCarts::Destroyer do
-  subject(:destroyer) { described_class.new(cart_uuid: cart_uuid) }
+  subject(:destroyer) { described_class.new(cart_uuid: cart_uuid, session: session) }
 
-  let(:cart) { create(:purchase_cart) }
+  let(:session) { create(:session) }
+  let(:cart) { create(:purchase_cart, session: session) }
   let(:cart_uuid) { cart.uuid }
 
   describe '#call' do

--- a/spec/actions/api/v1/purchase_carts/finder_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/finder_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PurchaseCarts::Finder do
-  subject(:finder) { described_class.new(cart_uuid: cart_uuid) }
+  subject(:finder) { described_class.new(cart_uuid: cart_uuid, session: session) }
 
-  let(:cart) { create(:purchase_cart) }
+  let(:session) { create(:session) }
+  let(:cart) { create(:purchase_cart, session: session) }
   let(:cart_uuid) { cart.uuid }
 
   describe '#call' do

--- a/spec/controllers/api/v1/cart_items_controller_spec.rb
+++ b/spec/controllers/api/v1/cart_items_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Api::V1::CartItemsController, type: :controller do
   render_views
 
   describe '#create' do
+    let(:session) { create(:session) }
     let(:payload) do
       {
         purchase_cart_uuid: cart.uuid,
@@ -11,7 +12,7 @@ RSpec.describe Api::V1::CartItemsController, type: :controller do
         quantity: 1
       }
     end
-    let(:cart) { create(:purchase_cart) }
+    let(:cart) { create(:purchase_cart, session: session) }
     let(:created_item) { create(:purchase_cart_item) }
     let(:creator_result) do
       instance_double('Creator Result', success?: true, failure?: false, value!: created_item)
@@ -22,6 +23,7 @@ RSpec.describe Api::V1::CartItemsController, type: :controller do
       allow(Api::V1::CartItems::Creator).to receive(:new).and_return creator
 
       request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
+      request.headers['X-SESSION-ID'] = session.uuid
       post :create, format: :json, params: payload
     end
 
@@ -89,7 +91,8 @@ RSpec.describe Api::V1::CartItemsController, type: :controller do
   end
 
   describe '#destroy' do
-    let(:cart) { create(:purchase_cart) }
+    let(:session) { create(:session) }
+    let(:cart) { create(:purchase_cart, session: session) }
     let(:cart_item) { create(:purchase_cart_item, purchase_cart: cart) }
     let(:destroyer_result) do
       instance_double('Destroyer Result', success?: true, failure?: false, value!: nil)
@@ -100,6 +103,7 @@ RSpec.describe Api::V1::CartItemsController, type: :controller do
       allow(Api::V1::CartItems::Destroyer).to receive(:new).and_return destroyer
 
       request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
+      request.headers['X-SESSION-ID'] = session.uuid
       delete :destroy, format: :json, params: { uuid: cart_item.uuid, purchase_cart_uuid: cart.uuid }
     end
 

--- a/spec/factories/purchase_cart.rb
+++ b/spec/factories/purchase_cart.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :purchase_cart do
+    association :session
+
     total_price { rand(0..5000) }
     status { PurchaseCart::STATUS_TYPES.sample }
   end

--- a/spec/models/purchase_cart_spec.rb
+++ b/spec/models/purchase_cart_spec.rb
@@ -6,12 +6,26 @@ RSpec.describe PurchaseCart, type: :model do
   describe 'associations' do
     it { is_expected.to have_many(:purchase_cart_items) }
     it { is_expected.to have_many(:purchase_cart_extra_fees) }
+    it { is_expected.to belong_to(:session) }
   end
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:total_price) }
     it { is_expected.to validate_presence_of(:status) }
     it { is_expected.to validate_inclusion_of(:status).in_array(PurchaseCart::STATUS_TYPES) }
+
+    describe 'when there is already an existing started cart associated to a session' do
+      let(:session) { create(:session) }
+      let(:purchase_cart) { build(:purchase_cart, session: session, status: PurchaseCart::STARTED) }
+
+      before do
+        create(:purchase_cart, session: session, status: PurchaseCart::STARTED)
+      end
+
+      it 'is not valid' do
+        expect(purchase_cart.valid?).to eq false
+      end
+    end
   end
 
   describe 'uuid' do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Session, type: :model do
   subject(:session) { build(:session) }
 
+  describe 'associations' do
+    it { is_expected.to have_many(:purchase_carts) }
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:ip_address) }
   end

--- a/spec/services/purchases/cart_canceler_spec.rb
+++ b/spec/services/purchases/cart_canceler_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Purchases::CartCanceler do
-  subject(:canceler) { described_class.new(cart_uuid: cart_uuid) }
+  subject(:canceler) { described_class.new(cart_uuid: cart_uuid, session: session) }
 
-  let(:cart) { create(:purchase_cart, status: cart_status) }
+  let(:session) { create(:session) }
+  let(:cart) { create(:purchase_cart, status: cart_status, session: session) }
   let(:cart_uuid) { cart.uuid }
   let(:cart_status) { PurchaseCart::STARTED }
 

--- a/spec/services/purchases/cart_item_generator_spec.rb
+++ b/spec/services/purchases/cart_item_generator_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Purchases::CartItemGenerator do
       stock_uuid: stock_uuid,
       quantity: quantity,
       cart: cart,
-      cart_uuid: cart_uuid
+      cart_uuid: cart_uuid,
+      session: session
     )
   end
 
@@ -16,6 +17,7 @@ RSpec.describe Purchases::CartItemGenerator do
   let(:quantity) { 5 }
   let(:stock_uuid) { stock.uuid }
   let(:cart_uuid) { nil }
+  let(:session) { nil }
 
   describe '#call' do
     describe 'when successful' do
@@ -35,7 +37,8 @@ RSpec.describe Purchases::CartItemGenerator do
     describe 'when passing cart_uuid instead of cart' do
       let(:cart) { nil }
       let(:cart_uuid) { target_cart.uuid }
-      let(:target_cart) { create(:purchase_cart) }
+      let(:target_cart) { create(:purchase_cart, session: session) }
+      let(:session) { create(:session) }
 
       before do
         generator.call

--- a/spec/services/purchases/cart_item_remover_spec.rb
+++ b/spec/services/purchases/cart_item_remover_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Purchases::CartItemRemover do
-  subject(:remover) { described_class.new(item_uuid: item_uuid) }
+  subject(:remover) { described_class.new(item_uuid: item_uuid, session: session) }
 
-  let(:cart) { create(:purchase_cart) }
+  let(:session) { create(:session) }
+  let(:cart) { create(:purchase_cart, session: session) }
   let(:cart_item) { create(:purchase_cart_item, purchase_cart: cart) }
   let(:item_uuid) { cart_item.uuid }
 
@@ -22,7 +23,7 @@ RSpec.describe Purchases::CartItemRemover do
       end
     end
 
-    describe 'when cart ite is not found' do
+    describe 'when cart item is not found' do
       before do
         allow(PurchaseCartItem).to receive(:find_by).and_return(nil)
       end


### PR DESCRIPTION
Closes #65
- Purchase carts are now tied to a session.
- Added a new #index endpoint to get all the purchase_carts for a session
- Added a new request header to receive the session_uuid and modify the cart and cart item endpoints to perform all the actions scoped in the domain of the current_session.