### PR TITLE
feat(Users): associate users with sessions

### DIFF
--- a/app/actions/api/v1/auth/confirmation.rb
+++ b/app/actions/api/v1/auth/confirmation.rb
@@ -6,14 +6,16 @@ module Api
 
         attr_reader :access_token
 
-        def initialize(params:)
+        def initialize(params:, session:)
           self.params = params
+          self.session = session
         end
 
         def call
           find_user
           check_code
           create_token
+          update_session
 
           Success(access_token)
         rescue ServiceError => e
@@ -25,7 +27,7 @@ module Api
 
         private
 
-        attr_accessor :params, :user, :verification_code
+        attr_accessor :params, :user, :verification_code, :session
         attr_writer :access_token
 
         def find_user
@@ -56,6 +58,10 @@ module Api
           self.access_token = token_generator.access_token
         rescue Authentication::AccessTokens::InvalidToken => e
           raise ServiceError, Failure({ code: :invalid_token, message: e.message })
+        end
+
+        def update_session
+          session.update!(user: user)
         end
       end
     end

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class AuthController < BaseController
       skip_before_action :authenticate_user_by_token!, only: %i[signup login confirmation]
+      before_action :authenticate_session_by_header!
 
       AUTH_ERROR_CODES = {
         invalid_user: 422,
@@ -26,7 +27,10 @@ module Api
       end
 
       def confirmation
-        confirmation_action = Api::V1::Auth::Confirmation.new(params: confirmation_params)
+        confirmation_action = Api::V1::Auth::Confirmation.new(
+          params: confirmation_params,
+          session: current_session
+        )
         result = confirmation_action.call
         return render_error_from(result) if result.failure?
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -3,5 +3,6 @@ class Session < ApplicationRecord
 
   validates :ip_address, presence: true
 
+  belongs_to :user, optional: true
   has_many :purchase_carts, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,6 @@ class User < ApplicationRecord
   has_many :access_tokens, dependent: :destroy
   has_many :user_locations, dependent: :destroy
   has_many :locations, through: :user_locations
+  has_many :sessions, dependent: :destroy
+  has_many :purchase_carts, through: :sessions
 end

--- a/db/migrate/20220828013349_add_user_id_to_sessions.rb
+++ b/db/migrate/20220828013349_add_user_id_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddUserIdToSessions < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :sessions, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_21_191920) do
+ActiveRecord::Schema.define(version: 2022_08_28_013349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,6 +162,8 @@ ActiveRecord::Schema.define(version: 2022_08_21_191920) do
     t.string "ip_address", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_sessions_on_user_id"
     t.index ["uuid"], name: "index_sessions_on_uuid", unique: true
   end
 
@@ -240,6 +242,7 @@ ActiveRecord::Schema.define(version: 2022_08_21_191920) do
   add_foreign_key "purchase_cart_items", "purchase_carts"
   add_foreign_key "purchase_cart_items", "stocks"
   add_foreign_key "purchase_carts", "sessions"
+  add_foreign_key "sessions", "users"
   add_foreign_key "stock_toppings", "stocks"
   add_foreign_key "stock_toppings", "toppings"
   add_foreign_key "stocks", "products"

--- a/spec/actions/api/v1/auth/confirmation_spec.rb
+++ b/spec/actions/api/v1/auth/confirmation_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Auth::Confirmation do
-  subject(:action) { described_class.new(params: { email: user_email, code: code }) }
+  subject(:action) { described_class.new(params: { email: user_email, code: code }, session: session) }
 
   let(:user) { create(:user) }
   let(:user_email) { user.email }
@@ -10,6 +10,7 @@ RSpec.describe Api::V1::Auth::Confirmation do
   let(:verification_code) { create(:verification_code, user: user, code: code) }
 
   let(:access_token) { create(:access_token, user: user, verification_code: verification_code) }
+  let(:session) { create(:session, user: nil) }
 
   describe '#call' do
     subject(:result) { action.call }
@@ -31,9 +32,14 @@ RSpec.describe Api::V1::Auth::Confirmation do
       expect(result.success?).to eq(true)
     end
 
-    it 'calls the code generator' do
+    it 'calls the code checker' do
       action.call
       expect(code_checker).to have_received(:call)
+    end
+
+    it 'updates the session with the user' do
+      action.call
+      expect(session.user).to eq(user)
     end
 
     describe 'when service fails due to unhandled error' do

--- a/spec/controllers/api/v1/auth_controller_spec.rb
+++ b/spec/controllers/api/v1/auth_controller_spec.rb
@@ -16,11 +16,13 @@ RSpec.describe Api::V1::AuthController, type: :controller do
       instance_double('Signup Result', success?: true, failure?: false, value!: nil)
     end
     let(:signup) { instance_double(Api::V1::Auth::Signup, call: signup_result) }
+    let(:session) { create(:session) }
 
     before do
       allow(Api::V1::Auth::Signup).to receive(:new).and_return signup
 
       request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
+      request.headers['X-SESSION-ID'] = session.uuid
       post :signup, format: :json, params: payload
     end
 
@@ -77,11 +79,13 @@ RSpec.describe Api::V1::AuthController, type: :controller do
       instance_double('Login Result', success?: true, failure?: false, value!: nil)
     end
     let(:login) { instance_double(Api::V1::Auth::Login, call: login_result) }
+    let(:session) { create(:session, user: user) }
 
     before do
       allow(Api::V1::Auth::Login).to receive(:new).and_return login
 
       request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
+      request.headers['X-SESSION-ID'] = session.uuid
       post :login, format: :json, params: payload
     end
 
@@ -145,11 +149,13 @@ RSpec.describe Api::V1::AuthController, type: :controller do
       instance_double('Confirmation Result', success?: true, failure?: false, value!: access_token)
     end
     let(:confirmation) { instance_double(Api::V1::Auth::Confirmation, call: confirmation_result) }
+    let(:session) { create(:session, user: user) }
 
     before do
       allow(Api::V1::Auth::Confirmation).to receive(:new).and_return confirmation
 
       request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
+      request.headers['X-SESSION-ID'] = session.uuid
       post :confirmation, format: :json, params: payload
     end
 
@@ -224,12 +230,14 @@ RSpec.describe Api::V1::AuthController, type: :controller do
       instance_double('Logout Result', success?: true, failure?: false, value!: nil)
     end
     let(:logout) { instance_double(Api::V1::Auth::Logout, call: logout_result) }
+    let(:session) { create(:session, user: user) }
 
     before do
       allow(Api::V1::Auth::Logout).to receive(:new).and_return logout
 
       request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
       request.headers['Authorization'] = "Bearer #{access_token.token}"
+      request.headers['X-SESSION-ID'] = session.uuid
       post :logout, format: :json
     end
 

--- a/spec/factories/session.rb
+++ b/spec/factories/session.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :session do
+    association :user
     ip_address { Faker::Internet.ip_v4_address }
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Session, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many(:purchase_carts) }
+    it { is_expected.to belong_to(:user).optional }
   end
 
   describe 'validations' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,5 +21,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:access_tokens) }
     it { is_expected.to have_many(:user_locations) }
     it { is_expected.to have_many(:locations) }
+    it { is_expected.to have_many(:sessions) }
+    it { is_expected.to have_many(:purchase_carts) }
   end
 end


### PR DESCRIPTION
Closes #96
- A 1:N relation is added between user and session models
- On the authentication flow, the session header will now be required on all endpoints. In the code confirmation endpoint, if the code is correct and the access token is generated, the session will be updated to associate it to the authenticated user.
- Users will now have Purchase Carts through the session model