### PR TITLE
feat(Payments): build webhook for Stripe events

### DIFF
--- a/app/actions/webhooks/v1/stripe/payment_handler.rb
+++ b/app/actions/webhooks/v1/stripe/payment_handler.rb
@@ -1,0 +1,62 @@
+module Webhooks
+  module V1
+    module Stripe
+      class PaymentHandler
+        SUCCESS_EVENT = 'payment_intent.succeeded'.freeze
+        FAILED_EVENT = 'payment_intent.payment_failed'.freeze
+
+        def initialize(body:)
+          self.body = body
+        end
+
+        def call
+          resolve_event_name
+          resolve_payment
+
+          save_event
+          dispatch_actions
+        end
+
+        private
+
+        attr_accessor :body, :event_name, :payment
+
+        def resolve_event_name
+          self.event_name = body['type']
+        end
+
+        def resolve_payment
+          payment_intent_id = body['data']['object']['id']
+          self.payment = Payment.find_by(provider_id: payment_intent_id)
+          return if payment.present?
+
+          raise Payments::PaymentNotFound, payment_intent_id
+        end
+
+        def save_event
+          payment.payment_events.create!(
+            event_name: event_name,
+            raw_data: body
+          )
+        rescue ActiveRecord::RecordNotSaved => e
+          Rails.logger.error "Could not save event: #{e.message}, payment id: #{payment.id}"
+        end
+
+        def dispatch_actions
+          case event_name
+          when SUCCESS_EVENT
+            success_dispatch
+          when FAILED_EVENT
+            failure_dispatch
+          end
+        end
+
+        # TODO: work on this logic later
+        def success_dispatch; end
+
+        # TODO: work on this logic later
+        def failure_dispatch; end
+      end
+    end
+  end
+end

--- a/app/controllers/webhooks/base_controller.rb
+++ b/app/controllers/webhooks/base_controller.rb
@@ -1,0 +1,4 @@
+module Webhooks
+  class BaseController < ApplicationController
+  end
+end

--- a/app/controllers/webhooks/v1/base_controller.rb
+++ b/app/controllers/webhooks/v1/base_controller.rb
@@ -1,0 +1,6 @@
+module Webhooks
+  module V1
+    class BaseController < Webhooks::BaseController
+    end
+  end
+end

--- a/app/controllers/webhooks/v1/stripe/base_controller.rb
+++ b/app/controllers/webhooks/v1/stripe/base_controller.rb
@@ -1,0 +1,8 @@
+module Webhooks
+  module V1
+    module Stripe
+      class BaseController < Webhooks::V1::BaseController
+      end
+    end
+  end
+end

--- a/app/controllers/webhooks/v1/stripe/payments_controller.rb
+++ b/app/controllers/webhooks/v1/stripe/payments_controller.rb
@@ -1,0 +1,27 @@
+module Webhooks
+  module V1
+    module Stripe
+      class PaymentsController < BaseController
+        def create
+          payment_handler.call
+
+          head :ok
+        rescue StandardError => e
+          Rails.logger.error(e)
+
+          head :ok
+        end
+
+        private
+
+        def request_body
+          @request_body ||= JSON.parse(request.body.string)
+        end
+
+        def payment_handler
+          @payment_handler ||= Webhooks::V1::Stripe::PaymentHandler.new(body: request_body)
+        end
+      end
+    end
+  end
+end

--- a/app/errors/payments/payment_not_found.rb
+++ b/app/errors/payments/payment_not_found.rb
@@ -1,0 +1,12 @@
+module Payments
+  class PaymentNotFound < StandardError
+    attr_reader :provider_id
+
+    def initialize(provider_id)
+      @provider_id = provider_id
+      message = "Stripe payment with provider_id #{provider_id} not found"
+
+      super(message)
+    end
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -3,6 +3,7 @@ class Payment < ApplicationRecord
 
   belongs_to :user
   belongs_to :purchase_cart
+  has_many :payment_events, dependent: :destroy
 
   validates :status, :amount, :provider_id, presence: true
 

--- a/app/models/payment_event.rb
+++ b/app/models/payment_event.rb
@@ -1,0 +1,6 @@
+class PaymentEvent < ApplicationRecord
+  belongs_to :payment
+
+  validates :event_name, presence: true
+  validates :raw_data, presence: true
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,6 +14,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.hosts << /.+\.ngrok\.io\z/
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   draw(:sidekiq)
   draw(:admin)
   draw(:api)
+  draw(:webhooks)
 end

--- a/config/routes/webhooks.rb
+++ b/config/routes/webhooks.rb
@@ -1,0 +1,7 @@
+namespace :webhooks do
+  namespace :v1 do
+    namespace :stripe do
+      resources :payments, only: %i[create]
+    end
+  end
+end

--- a/db/migrate/20220906010917_create_payment_events.rb
+++ b/db/migrate/20220906010917_create_payment_events.rb
@@ -1,0 +1,11 @@
+class CreatePaymentEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :payment_events do |t|
+      t.references :payment, null: false, foreign_key: true
+      t.jsonb :raw_data, null: false
+      t.string :event_name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_28_055739) do
+ActiveRecord::Schema.define(version: 2022_09_06_010917) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,15 @@ ActiveRecord::Schema.define(version: 2022_08_28_055739) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["longitude", "latitude"], name: "index_locations_on_longitude_and_latitude", unique: true
+  end
+
+  create_table "payment_events", force: :cascade do |t|
+    t.bigint "payment_id", null: false
+    t.jsonb "raw_data", null: false
+    t.string "event_name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["payment_id"], name: "index_payment_events_on_payment_id"
   end
 
   create_table "payments", force: :cascade do |t|
@@ -249,6 +258,7 @@ ActiveRecord::Schema.define(version: 2022_08_28_055739) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "email_communications", "communications"
+  add_foreign_key "payment_events", "payments"
   add_foreign_key "payments", "purchase_carts"
   add_foreign_key "payments", "users"
   add_foreign_key "product_contents", "products"

--- a/spec/actions/webhooks/v1/stripe/payment_handler_spec.rb
+++ b/spec/actions/webhooks/v1/stripe/payment_handler_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Webhooks::V1::Stripe::PaymentHandler do
+  subject(:handler) { described_class.new(body: body) }
+
+  let(:body) { JSON.parse(build(:payment_event, :created_intent).raw_data.to_json) }
+
+  describe '#call' do
+    before do
+      create(:payment, provider_id: 'pi_3Leos3LUUobuK6Uj1s2JY7yR')
+    end
+
+    it 'saves the payment event' do
+      expect { handler.call }.to change(PaymentEvent, :count).by(1)
+    end
+  end
+end

--- a/spec/controllers/webhooks/v1/stripe/payments_controller_spec.rb
+++ b/spec/controllers/webhooks/v1/stripe/payments_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Webhooks::V1::Stripe::PaymentsController, type: :controller do
+  render_views
+
+  describe '#create' do
+    let(:payment_event) { create(:payment_event, :created_intent) }
+    let(:payment_handler) { instance_double(Webhooks::V1::Stripe::PaymentHandler, call: true) }
+
+    before do
+      allow(Webhooks::V1::Stripe::PaymentHandler).to receive(:new).and_return(payment_handler)
+
+      post :create, body: payment_event.raw_data.to_json, format: :json
+    end
+
+    it 'returns success response' do
+      expect(response.status).to eq 200
+    end
+
+    it 'calls the webhook handler' do
+      expect(payment_handler).to have_received(:call)
+    end
+
+    describe 'when the handler raises an  error' do
+      before do
+        allow(Webhooks::V1::Stripe::PaymentHandler).to receive(:new).and_raise(StandardError.new('ERROR'))
+      end
+
+      it 'returns an error response' do
+        expect(response.status).to eq 200
+      end
+    end
+  end
+end

--- a/spec/factories/payment_event.rb
+++ b/spec/factories/payment_event.rb
@@ -1,0 +1,456 @@
+FactoryBot.define do
+  factory :payment_event do
+    association :payment
+
+    trait(:created_intent) do
+      event_name { 'payment_intent.created' }
+      raw_data do
+        {
+          'id' => 'evt_3Leos3LUUobuK6Uj1iBvNhkF',
+          'object' => 'event',
+          'api_version' => '2022-08-01',
+          'created' => 1_662_421_108,
+          'data' => {
+            'object' => {
+              'id' => 'pi_3Leos3LUUobuK6Uj1s2JY7yR',
+              'object' => 'payment_intent',
+              'amount' => 1400,
+              'amount_capturable' => 0,
+              'amount_details' => {
+                'tip' => {
+                }
+              },
+              'amount_received' => 0,
+              'application' => nil,
+              'application_fee_amount' => nil,
+              'automatic_payment_methods' => nil,
+              'canceled_at' => nil,
+              'cancellation_reason' => nil,
+              'capture_method' => 'automatic',
+              'charges' => {
+                'object' => 'list',
+                'data' => [],
+                'has_more' => false,
+                'total_count' => 0,
+                'url' => '/v1/charges?payment_intent=pi_3Leos3LUUobuK6Uj1s2JY7yR'
+              },
+              'client_secret' => 'pi_3Leos3LUUobuK6Uj1s2JY7yR_secret_fXaWrPPp6Lp1F2vQI0aemsM6y',
+              'confirmation_method' => 'automatic',
+              'created' => 1_662_421_107,
+              'currency' => 'usd',
+              'customer' => nil,
+              'description' => nil,
+              'invoice' => nil,
+              'last_payment_error' => nil,
+              'livemode' => false,
+              'metadata' => {
+              },
+              'next_action' => nil,
+              'on_behalf_of' => nil,
+              'payment_method' => nil,
+              'payment_method_options' => {
+                'card' => {
+                  'installments' => nil,
+                  'mandate_options' => nil,
+                  'network' => nil,
+                  'request_three_d_secure' => 'automatic'
+                }
+              },
+              'payment_method_types' => [
+                'card'
+              ],
+              'processing' => nil,
+              'receipt_email' => nil,
+              'review' => nil,
+              'setup_future_usage' => nil,
+              'shipping' => nil,
+              'source' => nil,
+              'statement_descriptor' => nil,
+              'statement_descriptor_suffix' => nil,
+              'status' => 'requires_payment_method',
+              'transfer_data' => nil,
+              'transfer_group' => nil
+            }
+          },
+          'livemode' => false,
+          'pending_webhooks' => 1,
+          'request' => {
+            'id' => 'req_HEJBjkhSyKXPBb',
+            'idempotency_key' => '9244b198-11e7-4435-8f20-537b29717020'
+          },
+          'type' => 'payment_intent.created'
+        }
+      end
+    end
+
+    trait(:succeeded_intent) do
+      event_name { 'payment_intent.succeeded' }
+      raw_data do
+        {
+          'id' => 'evt_3Leop4LUUobuK6Uj1wEQR3H5',
+          'object' => 'event',
+          'api_version' => '2022-08-01',
+          'created' => 1_662_420_975,
+          'data' => {
+            'object' => {
+              'id' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD',
+              'object' => 'payment_intent',
+              'amount' => 1400,
+              'amount_capturable' => 0,
+              'amount_details' => {
+                'tip' => {
+                }
+              },
+              'amount_received' => 1400,
+              'application' => nil,
+              'application_fee_amount' => nil,
+              'automatic_payment_methods' => {
+                'enabled' => true
+              },
+              'canceled_at' => nil,
+              'cancellation_reason' => nil,
+              'capture_method' => 'automatic',
+              'charges' => {
+                'object' => 'list',
+                'data' => [
+                  {
+                    'id' => 'ch_3Leop4LUUobuK6Uj14PqXB9h',
+                    'object' => 'charge',
+                    'amount' => 1400,
+                    'amount_captured' => 1400,
+                    'amount_refunded' => 0,
+                    'application' => nil,
+                    'application_fee' => nil,
+                    'application_fee_amount' => nil,
+                    'balance_transaction' => 'txn_3Leop4LUUobuK6Uj1WPnAQMk',
+                    'billing_details' => {
+                      'address' => {
+                        'city' => nil,
+                        'country' => 'CO',
+                        'line1' => nil,
+                        'line2' => nil,
+                        'postal_code' => nil,
+                        'state' => nil
+                      },
+                      'email' => nil,
+                      'name' => nil,
+                      'phone' => nil
+                    },
+                    'calculated_statement_descriptor' => 'Stripe',
+                    'captured' => true,
+                    'created' => 1_662_420_974,
+                    'currency' => 'usd',
+                    'customer' => nil,
+                    'description' => nil,
+                    'destination' => nil,
+                    'dispute' => nil,
+                    'disputed' => false,
+                    'failure_balance_transaction' => nil,
+                    'failure_code' => nil,
+                    'failure_message' => nil,
+                    'fraud_details' => {
+                    },
+                    'invoice' => nil,
+                    'livemode' => false,
+                    'metadata' => {
+                    },
+                    'on_behalf_of' => nil,
+                    'order' => nil,
+                    'outcome' => {
+                      'network_status' => 'approved_by_network',
+                      'reason' => nil,
+                      'risk_level' => 'normal',
+                      'risk_score' => 47,
+                      'seller_message' => 'Payment complete.',
+                      'type' => 'authorized'
+                    },
+                    'paid' => true,
+                    'payment_intent' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD',
+                    'payment_method' => 'pm_1LeoptLUUobuK6Uj3vcI07Ti',
+                    'payment_method_details' => {
+                      'card' => {
+                        'brand' => 'visa',
+                        'checks' => {
+                          'address_line1_check' => nil,
+                          'address_postal_code_check' => nil,
+                          'cvc_check' => 'pass'
+                        },
+                        'country' => 'US',
+                        'exp_month' => 6,
+                        'exp_year' => 2027,
+                        'fingerprint' => 'YkmER7KexEwEGyqI',
+                        'funding' => 'credit',
+                        'installments' => nil,
+                        'last4' => '4242',
+                        'mandate' => nil,
+                        'network' => 'visa',
+                        'three_d_secure' => nil,
+                        'wallet' => nil
+                      },
+                      'type' => 'card'
+                    },
+                    'receipt_email' => nil,
+                    'receipt_number' => nil,
+                    'receipt_url' => 'https=>//pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xTDIwR3JMVVVvYnVLNlVqKO-P2pgGMgZ4VPGcywM6LBacuFW2C00m8L4n9vdLwNNKT8_DMvPGPHh8mQDjfuO0kH-U4PBNsKLmWFvO',
+                    'refunded' => false,
+                    'refunds' => {
+                      'object' => 'list',
+                      'data' => [],
+                      'has_more' => false,
+                      'total_count' => 0,
+                      'url' => '/v1/charges/ch_3Leop4LUUobuK6Uj14PqXB9h/refunds'
+                    },
+                    'review' => nil,
+                    'shipping' => nil,
+                    'source' => nil,
+                    'source_transfer' => nil,
+                    'statement_descriptor' => nil,
+                    'statement_descriptor_suffix' => nil,
+                    'status' => 'succeeded',
+                    'transfer_data' => nil,
+                    'transfer_group' => nil
+                  }
+                ],
+                'has_more' => false,
+                'total_count' => 1,
+                'url' => '/v1/charges?payment_intent=pi_3Leop4LUUobuK6Uj1OfuNFxD'
+              },
+              'client_secret' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD_secret_ze5tydMKn1RUUyTBrDoFbrgRV',
+              'confirmation_method' => 'automatic',
+              'created' => 1_662_420_922,
+              'currency' => 'usd',
+              'customer' => nil,
+              'description' => nil,
+              'invoice' => nil,
+              'last_payment_error' => nil,
+              'livemode' => false,
+              'metadata' => {
+              },
+              'next_action' => nil,
+              'on_behalf_of' => nil,
+              'payment_method' => 'pm_1LeoptLUUobuK6Uj3vcI07Ti',
+              'payment_method_options' => {
+                'card' => {
+                  'installments' => nil,
+                  'mandate_options' => nil,
+                  'network' => nil,
+                  'request_three_d_secure' => 'automatic'
+                },
+                'link' => {
+                  'persistent_token' => nil
+                }
+              },
+              'payment_method_types' => %w[
+                card
+                link
+              ],
+              'processing' => nil,
+              'receipt_email' => nil,
+              'review' => nil,
+              'setup_future_usage' => nil,
+              'shipping' => nil,
+              'source' => nil,
+              'statement_descriptor' => nil,
+              'statement_descriptor_suffix' => nil,
+              'status' => 'succeeded',
+              'transfer_data' => nil,
+              'transfer_group' => nil
+            }
+          },
+          'livemode' => false,
+          'pending_webhooks' => 1,
+          'request' => {
+            'id' => 'req_s2i3S8R4P2aNE3',
+            'idempotency_key' => 'a04320cc-459d-407a-9cfa-b337891906df'
+          },
+          'type' => 'payment_intent.succeeded'
+        }
+      end
+    end
+
+    trait(:failed_intent) do
+      event_name { 'payment_intent.payment_failed' }
+      raw_data do
+        {
+          'id' => 'evt_3Leop4LUUobuK6Uj1wEQR3H5',
+          'object' => 'event',
+          'api_version' => '2022-08-01',
+          'created' => 1_662_420_975,
+          'data' => {
+            'object' => {
+              'id' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD',
+              'object' => 'payment_intent',
+              'amount' => 1400,
+              'amount_capturable' => 0,
+              'amount_details' => {
+                'tip' => {
+                }
+              },
+              'amount_received' => 1400,
+              'application' => nil,
+              'application_fee_amount' => nil,
+              'automatic_payment_methods' => {
+                'enabled' => true
+              },
+              'canceled_at' => nil,
+              'cancellation_reason' => nil,
+              'capture_method' => 'automatic',
+              'charges' => {
+                'object' => 'list',
+                'data' => [
+                  {
+                    'id' => 'ch_3Leop4LUUobuK6Uj14PqXB9h',
+                    'object' => 'charge',
+                    'amount' => 1400,
+                    'amount_captured' => 1400,
+                    'amount_refunded' => 0,
+                    'application' => nil,
+                    'application_fee' => nil,
+                    'application_fee_amount' => nil,
+                    'balance_transaction' => 'txn_3Leop4LUUobuK6Uj1WPnAQMk',
+                    'billing_details' => {
+                      'address' => {
+                        'city' => nil,
+                        'country' => 'CO',
+                        'line1' => nil,
+                        'line2' => nil,
+                        'postal_code' => nil,
+                        'state' => nil
+                      },
+                      'email' => nil,
+                      'name' => nil,
+                      'phone' => nil
+                    },
+                    'calculated_statement_descriptor' => 'Stripe',
+                    'captured' => true,
+                    'created' => 1_662_420_974,
+                    'currency' => 'usd',
+                    'customer' => nil,
+                    'description' => nil,
+                    'destination' => nil,
+                    'dispute' => nil,
+                    'disputed' => false,
+                    'failure_balance_transaction' => nil,
+                    'failure_code' => nil,
+                    'failure_message' => nil,
+                    'fraud_details' => {
+                    },
+                    'invoice' => nil,
+                    'livemode' => false,
+                    'metadata' => {
+                    },
+                    'on_behalf_of' => nil,
+                    'order' => nil,
+                    'outcome' => {
+                      'network_status' => 'approved_by_network',
+                      'reason' => nil,
+                      'risk_level' => 'normal',
+                      'risk_score' => 47,
+                      'seller_message' => 'Payment complete.',
+                      'type' => 'authorized'
+                    },
+                    'paid' => true,
+                    'payment_intent' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD',
+                    'payment_method' => 'pm_1LeoptLUUobuK6Uj3vcI07Ti',
+                    'payment_method_details' => {
+                      'card' => {
+                        'brand' => 'visa',
+                        'checks' => {
+                          'address_line1_check' => nil,
+                          'address_postal_code_check' => nil,
+                          'cvc_check' => 'pass'
+                        },
+                        'country' => 'US',
+                        'exp_month' => 6,
+                        'exp_year' => 2027,
+                        'fingerprint' => 'YkmER7KexEwEGyqI',
+                        'funding' => 'credit',
+                        'installments' => nil,
+                        'last4' => '4242',
+                        'mandate' => nil,
+                        'network' => 'visa',
+                        'three_d_secure' => nil,
+                        'wallet' => nil
+                      },
+                      'type' => 'card'
+                    },
+                    'receipt_email' => nil,
+                    'receipt_number' => nil,
+                    'receipt_url' => 'https=>//pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xTDIwR3JMVVVvYnVLNlVqKO-P2pgGMgZ4VPGcywM6LBacuFW2C00m8L4n9vdLwNNKT8_DMvPGPHh8mQDjfuO0kH-U4PBNsKLmWFvO',
+                    'refunded' => false,
+                    'refunds' => {
+                      'object' => 'list',
+                      'data' => [],
+                      'has_more' => false,
+                      'total_count' => 0,
+                      'url' => '/v1/charges/ch_3Leop4LUUobuK6Uj14PqXB9h/refunds'
+                    },
+                    'review' => nil,
+                    'shipping' => nil,
+                    'source' => nil,
+                    'source_transfer' => nil,
+                    'statement_descriptor' => nil,
+                    'statement_descriptor_suffix' => nil,
+                    'status' => 'succeeded',
+                    'transfer_data' => nil,
+                    'transfer_group' => nil
+                  }
+                ],
+                'has_more' => false,
+                'total_count' => 1,
+                'url' => '/v1/charges?payment_intent=pi_3Leop4LUUobuK6Uj1OfuNFxD'
+              },
+              'client_secret' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD_secret_ze5tydMKn1RUUyTBrDoFbrgRV',
+              'confirmation_method' => 'automatic',
+              'created' => 1_662_420_922,
+              'currency' => 'usd',
+              'customer' => nil,
+              'description' => nil,
+              'invoice' => nil,
+              'last_payment_error' => nil,
+              'livemode' => false,
+              'metadata' => {
+              },
+              'next_action' => nil,
+              'on_behalf_of' => nil,
+              'payment_method' => 'pm_1LeoptLUUobuK6Uj3vcI07Ti',
+              'payment_method_options' => {
+                'card' => {
+                  'installments' => nil,
+                  'mandate_options' => nil,
+                  'network' => nil,
+                  'request_three_d_secure' => 'automatic'
+                },
+                'link' => {
+                  'persistent_token' => nil
+                }
+              },
+              'payment_method_types' => %w[
+                card
+                link
+              ],
+              'processing' => nil,
+              'receipt_email' => nil,
+              'review' => nil,
+              'setup_future_usage' => nil,
+              'shipping' => nil,
+              'source' => nil,
+              'statement_descriptor' => nil,
+              'statement_descriptor_suffix' => nil,
+              'status' => 'succeeded',
+              'transfer_data' => nil,
+              'transfer_group' => nil
+            }
+          },
+          'livemode' => false,
+          'pending_webhooks' => 1,
+          'request' => {
+            'id' => 'req_s2i3S8R4P2aNE3',
+            'idempotency_key' => 'a04320cc-459d-407a-9cfa-b337891906df'
+          },
+          'type' => 'payment_intent.succeeded'
+        }
+      end
+    end
+  end
+end

--- a/spec/factories/payment_event.rb
+++ b/spec/factories/payment_event.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Layout/LineLength
 FactoryBot.define do
   factory :payment_event do
     association :payment
@@ -272,13 +273,13 @@ FactoryBot.define do
       event_name { 'payment_intent.payment_failed' }
       raw_data do
         {
-          'id' => 'evt_3Leop4LUUobuK6Uj1wEQR3H5',
+          'id' => 'evt_3Ler6NLUUobuK6Uj1sNkRsLP',
           'object' => 'event',
           'api_version' => '2022-08-01',
-          'created' => 1_662_420_975,
+          'created' => 1_662_429_834,
           'data' => {
             'object' => {
-              'id' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD',
+              'id' => 'pi_3Ler6NLUUobuK6Uj1kYhTH2O',
               'object' => 'payment_intent',
               'amount' => 1400,
               'amount_capturable' => 0,
@@ -286,7 +287,7 @@ FactoryBot.define do
                 'tip' => {
                 }
               },
-              'amount_received' => 1400,
+              'amount_received' => 0,
               'application' => nil,
               'application_fee_amount' => nil,
               'automatic_payment_methods' => {
@@ -299,15 +300,15 @@ FactoryBot.define do
                 'object' => 'list',
                 'data' => [
                   {
-                    'id' => 'ch_3Leop4LUUobuK6Uj14PqXB9h',
+                    'id' => 'ch_3Ler6NLUUobuK6Uj1hoHfjEt',
                     'object' => 'charge',
                     'amount' => 1400,
-                    'amount_captured' => 1400,
+                    'amount_captured' => 0,
                     'amount_refunded' => 0,
                     'application' => nil,
                     'application_fee' => nil,
                     'application_fee_amount' => nil,
-                    'balance_transaction' => 'txn_3Leop4LUUobuK6Uj1WPnAQMk',
+                    'balance_transaction' => nil,
                     'billing_details' => {
                       'address' => {
                         'city' => nil,
@@ -322,8 +323,8 @@ FactoryBot.define do
                       'phone' => nil
                     },
                     'calculated_statement_descriptor' => 'Stripe',
-                    'captured' => true,
-                    'created' => 1_662_420_974,
+                    'captured' => false,
+                    'created' => 1_662_429_833,
                     'currency' => 'usd',
                     'customer' => nil,
                     'description' => nil,
@@ -331,8 +332,8 @@ FactoryBot.define do
                     'dispute' => nil,
                     'disputed' => false,
                     'failure_balance_transaction' => nil,
-                    'failure_code' => nil,
-                    'failure_message' => nil,
+                    'failure_code' => 'card_declined',
+                    'failure_message' => 'Your card was declined. Your request was in test mode, but used a non test (live) card. For a list of valid test cards, visit=> https=>//stripe.com/docs/testing.',
                     'fraud_details' => {
                     },
                     'invoice' => nil,
@@ -342,31 +343,31 @@ FactoryBot.define do
                     'on_behalf_of' => nil,
                     'order' => nil,
                     'outcome' => {
-                      'network_status' => 'approved_by_network',
-                      'reason' => nil,
+                      'network_status' => 'not_sent_to_network',
+                      'reason' => 'test_mode_live_card',
                       'risk_level' => 'normal',
-                      'risk_score' => 47,
-                      'seller_message' => 'Payment complete.',
-                      'type' => 'authorized'
+                      'risk_score' => 50,
+                      'seller_message' => 'This charge request was in test mode, but did not use a Stripe test card number. For the list of these numbers, see stripe.com/docs/testing',
+                      'type' => 'invalid'
                     },
-                    'paid' => true,
-                    'payment_intent' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD',
-                    'payment_method' => 'pm_1LeoptLUUobuK6Uj3vcI07Ti',
+                    'paid' => false,
+                    'payment_intent' => 'pi_3Ler6NLUUobuK6Uj1kYhTH2O',
+                    'payment_method' => 'pm_1Ler8mLUUobuK6UjkHMTHoOn',
                     'payment_method_details' => {
                       'card' => {
                         'brand' => 'visa',
                         'checks' => {
                           'address_line1_check' => nil,
                           'address_postal_code_check' => nil,
-                          'cvc_check' => 'pass'
+                          'cvc_check' => 'unchecked'
                         },
-                        'country' => 'US',
+                        'country' => 'CO',
                         'exp_month' => 6,
                         'exp_year' => 2027,
-                        'fingerprint' => 'YkmER7KexEwEGyqI',
+                        'fingerprint' => 'QrRy4KN7BT02jBbf',
                         'funding' => 'credit',
                         'installments' => nil,
-                        'last4' => '4242',
+                        'last4' => '4857',
                         'mandate' => nil,
                         'network' => 'visa',
                         'three_d_secure' => nil,
@@ -376,14 +377,14 @@ FactoryBot.define do
                     },
                     'receipt_email' => nil,
                     'receipt_number' => nil,
-                    'receipt_url' => 'https=>//pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xTDIwR3JMVVVvYnVLNlVqKO-P2pgGMgZ4VPGcywM6LBacuFW2C00m8L4n9vdLwNNKT8_DMvPGPHh8mQDjfuO0kH-U4PBNsKLmWFvO',
+                    'receipt_url' => nil,
                     'refunded' => false,
                     'refunds' => {
                       'object' => 'list',
                       'data' => [],
                       'has_more' => false,
                       'total_count' => 0,
-                      'url' => '/v1/charges/ch_3Leop4LUUobuK6Uj14PqXB9h/refunds'
+                      'url' => '/v1/charges/ch_3Ler6NLUUobuK6Uj1hoHfjEt/refunds'
                     },
                     'review' => nil,
                     'shipping' => nil,
@@ -391,29 +392,84 @@ FactoryBot.define do
                     'source_transfer' => nil,
                     'statement_descriptor' => nil,
                     'statement_descriptor_suffix' => nil,
-                    'status' => 'succeeded',
+                    'status' => 'failed',
                     'transfer_data' => nil,
                     'transfer_group' => nil
                   }
                 ],
                 'has_more' => false,
                 'total_count' => 1,
-                'url' => '/v1/charges?payment_intent=pi_3Leop4LUUobuK6Uj1OfuNFxD'
+                'url' => '/v1/charges?payment_intent=pi_3Ler6NLUUobuK6Uj1kYhTH2O'
               },
-              'client_secret' => 'pi_3Leop4LUUobuK6Uj1OfuNFxD_secret_ze5tydMKn1RUUyTBrDoFbrgRV',
+              'client_secret' => 'pi_3Ler6NLUUobuK6Uj1kYhTH2O_secret_O7lNh3QVqSHQ3WxITyF21FzYL',
               'confirmation_method' => 'automatic',
-              'created' => 1_662_420_922,
+              'created' => 1_662_429_683,
               'currency' => 'usd',
               'customer' => nil,
               'description' => nil,
               'invoice' => nil,
-              'last_payment_error' => nil,
+              'last_payment_error' => {
+                'charge' => 'ch_3Ler6NLUUobuK6Uj1hoHfjEt',
+                'code' => 'card_declined',
+                'decline_code' => 'test_mode_live_card',
+                'doc_url' => 'https=>//stripe.com/docs/error-codes/card-declined',
+                'message' => 'Your card was declined. Your request was in test mode, but used a non test (live) card. For a list of valid test cards, visit=> https=>//stripe.com/docs/testing.',
+                'payment_method' => {
+                  'id' => 'pm_1Ler8mLUUobuK6UjkHMTHoOn',
+                  'object' => 'payment_method',
+                  'billing_details' => {
+                    'address' => {
+                      'city' => nil,
+                      'country' => 'CO',
+                      'line1' => nil,
+                      'line2' => nil,
+                      'postal_code' => nil,
+                      'state' => nil
+                    },
+                    'email' => nil,
+                    'name' => nil,
+                    'phone' => nil
+                  },
+                  'card' => {
+                    'brand' => 'visa',
+                    'checks' => {
+                      'address_line1_check' => nil,
+                      'address_postal_code_check' => nil,
+                      'cvc_check' => 'unchecked'
+                    },
+                    'country' => 'CO',
+                    'exp_month' => 6,
+                    'exp_year' => 2027,
+                    'fingerprint' => 'QrRy4KN7BT02jBbf',
+                    'funding' => 'credit',
+                    'generated_from' => nil,
+                    'last4' => '4857',
+                    'networks' => {
+                      'available' => [
+                        'visa'
+                      ],
+                      'preferred' => nil
+                    },
+                    'three_d_secure_usage' => {
+                      'supported' => true
+                    },
+                    'wallet' => nil
+                  },
+                  'created' => 1_662_429_833,
+                  'customer' => nil,
+                  'livemode' => false,
+                  'metadata' => {
+                  },
+                  'type' => 'card'
+                },
+                'type' => 'card_error'
+              },
               'livemode' => false,
               'metadata' => {
               },
               'next_action' => nil,
               'on_behalf_of' => nil,
-              'payment_method' => 'pm_1LeoptLUUobuK6Uj3vcI07Ti',
+              'payment_method' => nil,
               'payment_method_options' => {
                 'card' => {
                   'installments' => nil,
@@ -437,7 +493,7 @@ FactoryBot.define do
               'source' => nil,
               'statement_descriptor' => nil,
               'statement_descriptor_suffix' => nil,
-              'status' => 'succeeded',
+              'status' => 'requires_payment_method',
               'transfer_data' => nil,
               'transfer_group' => nil
             }
@@ -445,12 +501,13 @@ FactoryBot.define do
           'livemode' => false,
           'pending_webhooks' => 1,
           'request' => {
-            'id' => 'req_s2i3S8R4P2aNE3',
-            'idempotency_key' => 'a04320cc-459d-407a-9cfa-b337891906df'
+            'id' => 'req_ZjW6jrEoE3biCs',
+            'idempotency_key' => '22dd4225-3ab4-4e40-bac6-eeb50ef32e73'
           },
-          'type' => 'payment_intent.succeeded'
+          'type' => 'payment_intent.payment_failed'
         }
       end
     end
   end
 end
+# rubocop:enable Layout/LineLength

--- a/spec/models/payment_event_spec.rb
+++ b/spec/models/payment_event_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe PaymentEvent, type: :model do
+  subject { build(:payment_event, :created_intent) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:payment) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:event_name) }
+    it { is_expected.to validate_presence_of(:raw_data) }
+  end
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Payment, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:purchase_cart) }
+    it { is_expected.to have_many(:payment_events).dependent(:destroy) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
Closes #103 
A new endpoint is added to listen events sent by Stripe during the payment flow. When an event is received, for now it is just associated to a payment record on the db, and the event data is saved on a separate table as well. Further actions will be done in separate issues