### PR TITLE
feat(Payments): build success dispatch

### DIFF
--- a/app/actions/webhooks/v1/stripe/payment_handler.rb
+++ b/app/actions/webhooks/v1/stripe/payment_handler.rb
@@ -51,8 +51,9 @@ module Webhooks
           end
         end
 
-        # TODO: work on this logic later
-        def success_dispatch; end
+        def success_dispatch
+          ::Payments::SuccessDispatch.new(payment: payment).call
+        end
 
         # TODO: work on this logic later
         def failure_dispatch; end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,7 @@
 class Order < ApplicationRecord
   belongs_to :payment
   belongs_to :user_location
+  has_one :purchase_cart, through: :payment
 
   validates :status, presence: true
 

--- a/app/models/purchase_cart.rb
+++ b/app/models/purchase_cart.rb
@@ -19,6 +19,7 @@ class PurchaseCart < ApplicationRecord
   has_many :purchase_cart_extra_fees, dependent: :destroy
   has_many :payments, dependent: :destroy
   belongs_to :session
+  belongs_to :user_location, optional: true
   has_one :user, through: :session
 
   scope :started, -> { where(status: STARTED) }

--- a/app/models/purchase_cart_item.rb
+++ b/app/models/purchase_cart_item.rb
@@ -11,4 +11,9 @@ class PurchaseCartItem < ApplicationRecord
   def total_price
     (unit_price * quantity).to_f
   end
+
+  def reduce_stock_amount!
+    new_amount = stock.quantity - quantity
+    stock.update!(quantity: new_amount)
+  end
 end

--- a/app/services/orders/start_order.rb
+++ b/app/services/orders/start_order.rb
@@ -1,0 +1,34 @@
+module Orders
+  class StartOrder
+    attr_reader :order
+
+    def initialize(payment:)
+      self.payment = payment
+    end
+
+    def call
+      ActiveRecord::Base.Transaction do
+        create_order
+        reduce_stocks_amounts
+      end
+    end
+
+    private
+
+    attr_accessor :payment
+    attr_writer :order
+
+    def create_order
+      self.order = Order.create!(
+        payment: payment,
+        user_location: payment.purchase_cart.user_location,
+        status: Order::ACTIVE
+      )
+    end
+
+    def reduce_stocks_amounts
+      cart_items = order.purchase_cart.purchase_cart_items
+      cart_items.each(&:reduce_stock_amount!)
+    end
+  end
+end

--- a/app/services/orders/start_order.rb
+++ b/app/services/orders/start_order.rb
@@ -7,7 +7,7 @@ module Orders
     end
 
     def call
-      ActiveRecord::Base.Transaction do
+      ActiveRecord::Base.transaction do
         create_order
         reduce_stocks_amounts
       end

--- a/app/services/payments/success_dispatch.rb
+++ b/app/services/payments/success_dispatch.rb
@@ -5,7 +5,7 @@ module Payments
     end
 
     def call
-      ActiveRecord::Base.Transaction do
+      ActiveRecord::Base.transaction do
         update_payment_status
         update_cart_status
         start_order

--- a/app/services/payments/success_dispatch.rb
+++ b/app/services/payments/success_dispatch.rb
@@ -1,0 +1,31 @@
+module Payments
+  class SuccessDispatch
+    def initialize(payment:)
+      self.payment = payment
+    end
+
+    def call
+      ActiveRecord::Base.Transaction do
+        update_payment_status
+        update_cart_status
+        start_order
+      end
+    end
+
+    private
+
+    attr_accessor :payment
+
+    def update_payment_status
+      payment.update!(status: Payment::COMPLETED)
+    end
+
+    def update_cart_status
+      payment.purchase_cart.update!(status: PurchaseCart::PAID)
+    end
+
+    def start_order
+      Orders::StartOrder.new(payment: payment).call
+    end
+  end
+end

--- a/db/migrate/20220912050930_add_user_location_to_purchase_carts.rb
+++ b/db/migrate/20220912050930_add_user_location_to_purchase_carts.rb
@@ -1,0 +1,5 @@
+class AddUserLocationToPurchaseCarts < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :purchase_carts, :user_location, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_06_034157) do
+ActiveRecord::Schema.define(version: 2022_09_12_050930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,7 +185,9 @@ ActiveRecord::Schema.define(version: 2022_09_06_034157) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "session_id", null: false
+    t.bigint "user_location_id"
     t.index ["session_id"], name: "index_purchase_carts_on_session_id"
+    t.index ["user_location_id"], name: "index_purchase_carts_on_user_location_id"
     t.index ["uuid"], name: "index_purchase_carts_on_uuid", unique: true
   end
 
@@ -279,6 +281,7 @@ ActiveRecord::Schema.define(version: 2022_09_06_034157) do
   add_foreign_key "purchase_cart_items", "purchase_carts"
   add_foreign_key "purchase_cart_items", "stocks"
   add_foreign_key "purchase_carts", "sessions"
+  add_foreign_key "purchase_carts", "user_locations"
   add_foreign_key "sessions", "users"
   add_foreign_key "stock_toppings", "stocks"
   add_foreign_key "stock_toppings", "toppings"

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Order, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:payment) }
     it { is_expected.to belong_to(:user_location) }
+    it { is_expected.to have_one(:purchase_cart).through(:payment) }
   end
 
   describe 'validations' do

--- a/spec/models/purchase_cart_item_spec.rb
+++ b/spec/models/purchase_cart_item_spec.rb
@@ -32,4 +32,17 @@ RSpec.describe PurchaseCartItem, type: :model do
       expect(cart_item.uuid).not_to be_nil
     end
   end
+
+  describe '#reduce_stock_amount!' do
+    let(:stock) { create(:stock, quantity: 10) }
+    let(:cart_item) { create(:purchase_cart_item, stock: stock, quantity: 3) }
+
+    before do
+      cart_item.reduce_stock_amount!
+    end
+
+    it 'reduces the stock amount to 7' do
+      expect(stock.quantity).to eq(7)
+    end
+  end
 end

--- a/spec/models/purchase_cart_spec.rb
+++ b/spec/models/purchase_cart_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PurchaseCart, type: :model do
     it { is_expected.to have_many(:purchase_cart_items) }
     it { is_expected.to have_many(:purchase_cart_extra_fees) }
     it { is_expected.to belong_to(:session) }
+    it { is_expected.to belong_to(:user_location).optional }
     it { is_expected.to have_many(:payments) }
     it { is_expected.to have_one(:user).through(:session) }
   end

--- a/spec/services/orders/start_order_spec.rb
+++ b/spec/services/orders/start_order_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Orders::StartOrder do
+  subject(:starter) { described_class.new(payment: payment) }
+
+  let(:user_location) { create(:user_location, location: create(:colpatria_tower_co)) }
+  let(:purchase_cart) do
+    create(:purchase_cart, user_location: user_location, purchase_cart_items: create_list(:purchase_cart_item, 10))
+  end
+  let(:payment) { create(:payment, purchase_cart: purchase_cart0) }
+
+  describe '#call' do
+    subject(:result) { starter.call }
+
+    before do
+      allow_any_instance_of(PurchaseCartItem).to receive(:reduce_stock_amount!)
+    end
+
+    it ""
+  end
+end

--- a/spec/services/orders/start_order_spec.rb
+++ b/spec/services/orders/start_order_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Orders::StartOrder do
   end
   let(:payment) { create(:payment, purchase_cart: purchase_cart0) }
 
-  describe '#call' do
-    subject(:result) { starter.call }
+  # describe '#call' do
+  #   subject(:result) { starter.call }
 
-    before do
-      allow_any_instance_of(PurchaseCartItem).to receive(:reduce_stock_amount!)
-    end
+  #   before do
+  #     allow_any_instance_of(PurchaseCartItem).to receive(:reduce_stock_amount!)
+  #   end
 
-    it ""
-  end
+  #   it ''
+  # end
 end

--- a/spec/services/payments/success_dispatch_spec.rb
+++ b/spec/services/payments/success_dispatch_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Payments::SuccessDispatch do
+  subject(:dispatch) { described_class.new(payment: payment) }
+
+  let(:payment) { create(:payment, purchase_cart: purchase_cart) }
+  let(:purchase_cart) { create(:purchase_cart) }
+
+  let(:order_starter) { instance_double(Orders::StartOrder, call: true) }
+
+  describe '#call' do
+    before do
+      allow(Orders::StartOrder).to receive(:new).and_return(order_starter)
+
+      dispatch.call
+    end
+
+    it 'updates the payment status' do
+      expect(payment.status).to eq(Payment::COMPLETED)
+    end
+
+    it 'updates the cart status' do
+      expect(purchase_cart.status).to eq(PurchaseCart::PAID)
+    end
+
+    it 'calls the order starter' do
+      expect(order_starter).to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
Closes #116 
A new service class is added to handle all the actions needed when a payment is successful. One of these actions is to create an order, for which a separate abstraction is added. This abstraction will create the order with an "active" status and will reduce the stock amount of each cart item.

Also, a new relation between user_locations and purchase_carts is added. Since the user location will not be known when a cart is created, a new endpoint to update the cart when the location is known will be added on #127 

This PR is still a draft, some specs are missing for `Orders::StartOrder` and `Payments::SuccessDispatch`