### PR TITLE
feat(Payments): build failure dispatch

### DIFF
--- a/app/actions/webhooks/v1/stripe/payment_handler.rb
+++ b/app/actions/webhooks/v1/stripe/payment_handler.rb
@@ -55,8 +55,9 @@ module Webhooks
           ::Payments::SuccessDispatch.new(payment: payment).call
         end
 
-        # TODO: work on this logic later
-        def failure_dispatch; end
+        def failure_dispatch
+          ::Payments::FailureDispatch.new(payment: payment).call
+        end
       end
     end
   end

--- a/app/services/payments/failure_dispatch.rb
+++ b/app/services/payments/failure_dispatch.rb
@@ -1,0 +1,21 @@
+module Payments
+  class FailureDispatch
+    def initialize(payment:)
+      self.payment = payment
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        update_payment_status
+      end
+    end
+
+    private
+
+    attr_accessor :payment
+
+    def update_payment_status
+      payment.update!(status: Payment::CANCELED)
+    end
+  end
+end

--- a/spec/actions/webhooks/v1/stripe/payment_handler_spec.rb
+++ b/spec/actions/webhooks/v1/stripe/payment_handler_spec.rb
@@ -13,5 +13,37 @@ RSpec.describe Webhooks::V1::Stripe::PaymentHandler do
     it 'saves the payment event' do
       expect { handler.call }.to change(PaymentEvent, :count).by(1)
     end
+
+    describe 'when payment event is a successful payment' do
+      let(:body) { JSON.parse(build(:payment_event, :succeeded_intent).raw_data.to_json) }
+      let(:success_dispatch) { instance_double(Payments::SuccessDispatch, call: true) }
+
+      before do
+        create(:payment, provider_id: 'pi_3Leop4LUUobuK6Uj1OfuNFxD')
+        allow(Payments::SuccessDispatch).to receive(:new).and_return(success_dispatch)
+      end
+
+      it 'calls the success handler' do
+        handler.call
+
+        expect(success_dispatch).to have_received(:call)
+      end
+    end
+
+    describe 'when payment event is a failed payment' do
+      let(:body) { JSON.parse(build(:payment_event, :failed_intent).raw_data.to_json) }
+      let(:failure_dispatch) { instance_double(Payments::FailureDispatch, call: true) }
+
+      before do
+        create(:payment, provider_id: 'pi_3Ler6NLUUobuK6Uj1kYhTH2O')
+        allow(Payments::FailureDispatch).to receive(:new).and_return(failure_dispatch)
+      end
+
+      it 'calls the success handler' do
+        handler.call
+
+        expect(failure_dispatch).to have_received(:call)
+      end
+    end
   end
 end

--- a/spec/services/payments/failure_dispatch_spec.rb
+++ b/spec/services/payments/failure_dispatch_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Payments::FailureDispatch do
+  subject(:dispatch) { described_class.new(payment: payment) }
+
+  let(:payment) { create(:payment, status: Payment::STARTED) }
+
+  describe '#call' do
+    before do
+      dispatch.call
+    end
+
+    it 'updates the payment status' do
+      expect(payment.status).to eq(Payment::CANCELED)
+    end
+  end
+end


### PR DESCRIPTION
Closes #117 
This PR implements a FailureDispatch abstraction that would gather all the actions that need to be done when Stripe notifies us through the webhook that a payment intent failed

For now the failure dispatch just updates the payment status to CANCELED