### PR TITLE
feat(Payments): send success email

### DIFF
--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -6,7 +6,10 @@ class Communication < ApplicationRecord
   validates :topic, presence: true
 
   VERIFICATION_CODE_TOPIC = 'verification_code'
+  SUCCESS_PAYMENT_TOPIC = 'success_payment'
+
   TOPICS = [
-    VERIFICATION_CODE_TOPIC
+    VERIFICATION_CODE_TOPIC,
+    SUCCESS_PAYMENT_TOPIC
   ].freeze
 end

--- a/app/models/email_communication.rb
+++ b/app/models/email_communication.rb
@@ -7,7 +7,10 @@ class EmailCommunication < ApplicationRecord
   validates :sender, :recipient, :template_id, :template_data, presence: true
 
   AUTH_SENDER_EMAIL = 'auth@audiophiley.com'
+  PAYMENTS_SENDER_EMAIL = 'payments@audiophiley.com'
+
   SENDERS = [
-    AUTH_SENDER_EMAIL
+    AUTH_SENDER_EMAIL,
+    PAYMENTS_SENDER_EMAIL
   ].freeze
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,6 @@
 class Order < ApplicationRecord
+  include UuidHandler
+
   belongs_to :payment
   belongs_to :user_location
   has_one :purchase_cart, through: :payment

--- a/app/services/payments/success_dispatch.rb
+++ b/app/services/payments/success_dispatch.rb
@@ -9,6 +9,7 @@ module Payments
         update_payment_status
         update_cart_status
         start_order
+        send_success_email
       end
     end
 
@@ -25,7 +26,15 @@ module Payments
     end
 
     def start_order
-      Orders::StartOrder.new(payment: payment).call
+      order_starter.call
+    end
+
+    def order_starter
+      @order_starter ||= Orders::StartOrder.new(payment: payment)
+    end
+
+    def send_success_email
+      Payments::SuccessEmailSender.new(payment: payment, order: order_starter.order).call
     end
   end
 end

--- a/app/services/payments/success_email_sender.rb
+++ b/app/services/payments/success_email_sender.rb
@@ -1,0 +1,65 @@
+module Payments
+  class SuccessEmailSender
+    SUCCESS_EMAIL_TEMPLATE_ID = 'd-725277b4a66441d98b0659a5057578ac'.freeze
+
+    def initialize(payment:, order:)
+      self.payment = payment
+      self.order = order
+    end
+
+    def call
+      resolve_recipient
+      build_template_data
+
+      send_email
+    end
+
+    private
+
+    attr_accessor :payment, :order, :recipient, :template_data
+
+    def resolve_recipient
+      self.recipient = payment.user.email
+    end
+
+    def build_template_data
+      self.template_data = {
+        user_name: payment.user.name,
+        total_price: payment.amount,
+        order_uuid: order.uuid,
+        cart_items: serialize_cart_items,
+        extra_fees: serialize_extra_fees
+      }
+    end
+
+    def serialize_cart_items
+      payment.purchase_cart.purchase_cart_items.map do |cart_item|
+        {
+          name: cart_item.stock.product.name,
+          quantity: cart_item.quantity,
+          total_price: cart_item.total_price
+        }
+      end
+    end
+
+    def serialize_extra_fees
+      payment.purchase_cart.purchase_cart_extra_fees.map do |extra_fee|
+        {
+          name: extra_fee.key.humanize,
+          total_price: extra_fee.price
+        }
+      end
+    end
+
+    def send_email
+      Communications::EmailSenderJob.perform_later(
+        topic: Communication::SUCCESS_PAYMENT_TOPIC,
+        sender: EmailCommunication::PAYMENTS_SENDER_EMAIL,
+        recipient: recipient,
+        template_id: SUCCESS_EMAIL_TEMPLATE_ID,
+        template_data: template_data,
+        target: payment.user
+      )
+    end
+  end
+end

--- a/db/migrate/20221002064845_add_uuid_to_orders.rb
+++ b/db/migrate/20221002064845_add_uuid_to_orders.rb
@@ -1,6 +1,6 @@
 class AddUuidToOrders < ActiveRecord::Migration[6.1]
   def change
     add_column :orders, :uuid, :string, null: false
-    add_index :orders, :uuid, :unique => true
+    add_index :orders, :uuid, unique: true
   end
 end

--- a/db/migrate/20221002064845_add_uuid_to_orders.rb
+++ b/db/migrate/20221002064845_add_uuid_to_orders.rb
@@ -1,0 +1,6 @@
+class AddUuidToOrders < ActiveRecord::Migration[6.1]
+  def change
+    add_column :orders, :uuid, :string, null: false
+    add_index :orders, :uuid, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_12_050930) do
+ActiveRecord::Schema.define(version: 2022_10_02_064845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,8 +96,10 @@ ActiveRecord::Schema.define(version: 2022_09_12_050930) do
     t.string "status", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "uuid", null: false
     t.index ["payment_id"], name: "index_orders_on_payment_id"
     t.index ["user_location_id"], name: "index_orders_on_user_location_id"
+    t.index ["uuid"], name: "index_orders_on_uuid", unique: true
   end
 
   create_table "payment_events", force: :cascade do |t|

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
-  subject { build(:order) }
+  subject(:order) { build(:order) }
 
   describe 'associations' do
     it { is_expected.to belong_to(:payment) }
@@ -11,5 +11,19 @@ RSpec.describe Order, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:status) }
+  end
+
+  describe 'uuid' do
+    before do
+      order.uuid = nil
+
+      VCR.use_cassette('geocoder_response', match_requests_on: %i[method host path]) do
+        order.save
+      end
+    end
+
+    it 'is generated on creation' do
+      expect(order.uuid).not_to be_nil
+    end
   end
 end

--- a/spec/services/payments/success_dispatch_spec.rb
+++ b/spec/services/payments/success_dispatch_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe Payments::SuccessDispatch do
   let(:payment) { create(:payment, purchase_cart: purchase_cart) }
   let(:purchase_cart) { create(:purchase_cart) }
 
-  let(:order_starter) { instance_double(Orders::StartOrder, call: true) }
+  let(:order_starter) { instance_double(Orders::StartOrder, call: true, order: anything) }
+  let(:success_email_sender) { instance_double(Payments::SuccessEmailSender, call: true) }
 
   describe '#call' do
     before do
       allow(Orders::StartOrder).to receive(:new).and_return(order_starter)
+      allow(Payments::SuccessEmailSender).to receive(:new).and_return(success_email_sender)
 
       dispatch.call
     end
@@ -25,6 +27,10 @@ RSpec.describe Payments::SuccessDispatch do
 
     it 'calls the order starter' do
       expect(order_starter).to have_received(:call)
+    end
+
+    it 'calls the success email sender' do
+      expect(success_email_sender).to have_received(:call)
     end
   end
 end

--- a/spec/services/payments/success_email_sender_spec.rb
+++ b/spec/services/payments/success_email_sender_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Payments::SuccessEmailSender do
+  subject(:sender) { described_class.new(payment: payment, order: order) }
+
+  let(:payment) { create(:payment, status: Payment::COMPLETED) }
+  let(:order) do
+    VCR.use_cassette('geocoder_response', match_requests_on: %i[method host path]) do
+      create(:order, payment: payment, status: Order::ACTIVE)
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(Communications::EmailSenderJob).to receive(:perform_later).and_return(true)
+
+      sender.call
+    end
+
+    it 'sends the email' do
+      expect(Communications::EmailSenderJob).to have_received(:perform_later)
+    end
+  end
+end


### PR DESCRIPTION
Closes #119 

A new email is built to be sent when the payment is succeeded
![image](https://user-images.githubusercontent.com/27536621/193442593-da2ca3e2-43dd-405b-bf2a-626553304828.png)