### PR TITLE
chore(Gemfile): add apple m2 platform to lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
This is just a change that my MacBook is doing automatically whenever the project is open.