### PR TITLE
fix(rake tasks): add environment condition to library imports

### DIFF
--- a/lib/tasks/seeds/e2e.rake
+++ b/lib/tasks/seeds/e2e.rake
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-require 'factory_bot'
-require 'faker'
+if Rails.env.test?
+  require 'factory_bot'
+  require 'faker'
+end
 
 namespace :seeds do
   desc 'Seeds the DB with enough data for E2E tests'


### PR DESCRIPTION
Given the way how rake tasks work, rake preloads ALL the `*.rake` files when you run any rake task. This is causing some issues because on the e2e task we are importing some libraries that are only available for testing or development environments. On staging, though, we are not installing those gems, so when trying to run any other rake task (like `rails db:migrate`) it fails because it preloads the e2e task and can't find the required libraries.

Adding an environment condition to import those libraries fixes the issue