### PR TITLE
feat(page views): build endpoint and model to track session page views

### DIFF
--- a/app/actions/api/v1/page_views/creator.rb
+++ b/app/actions/api/v1/page_views/creator.rb
@@ -1,0 +1,36 @@
+module Api
+  module V1
+    module PageViews
+      class Creator
+        include Dry::Monads[:result]
+
+        attr_reader :page_view
+
+        def initialize(session:, params:)
+          self.session = session
+          self.params = params
+        end
+
+        def call
+          create_page_view
+
+          Success(page_view)
+        rescue ServiceError => e
+          e.failure
+        rescue StandardError => e
+          Rails.logger.error(e)
+          Failure({ code: :internal_error })
+        end
+
+        private
+
+        attr_writer :page_view
+        attr_accessor :session, :params
+
+        def create_page_view
+          self.page_view = session.page_views.create!(params)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/page_views_controller.rb
+++ b/app/controllers/api/v1/page_views_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    class PageViewsController < BaseController
+      skip_before_action :authenticate_user_by_token!
+      before_action :authenticate_session_by_header!
+
+      def create
+        creator = Api::V1::PageViews::Creator.new(
+          session: current_session,
+          params: page_view_params
+        )
+        result = creator.call
+        return render_error_from(result) if result.failure?
+
+        @user_location = result.value!
+      end
+
+      private
+
+      def page_view_params
+        params.permit(:page_path, :query_params)
+      end
+    end
+  end
+end

--- a/app/models/page_view.rb
+++ b/app/models/page_view.rb
@@ -1,0 +1,3 @@
+class PageView < ApplicationRecord
+  belongs_to :session
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -5,4 +5,5 @@ class Session < ApplicationRecord
 
   belongs_to :user, optional: true
   has_many :purchase_carts, dependent: :destroy
+  has_many :page_views, dependent: :destroy
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -17,5 +17,6 @@ namespace :api do
     resources :sessions, only: %i[create], param: :uuid
     resources :locations, only: %i[create index]
     resources :payments, only: %i[create index]
+    resources :page_views, only: %i[create]
   end
 end

--- a/db/migrate/20221222024311_create_page_views.rb
+++ b/db/migrate/20221222024311_create_page_views.rb
@@ -1,0 +1,13 @@
+class CreatePageViews < ActiveRecord::Migration[6.1]
+  def change
+    create_table :page_views do |t|
+      t.references :session, null: false, foreign_key: true
+      t.string :page_path, null: false
+      t.string :query_params
+
+      t.timestamps
+    end
+
+    add_index :page_views, :page_path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_02_064845) do
+ActiveRecord::Schema.define(version: 2022_12_22_024311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,6 +100,16 @@ ActiveRecord::Schema.define(version: 2022_10_02_064845) do
     t.index ["payment_id"], name: "index_orders_on_payment_id"
     t.index ["user_location_id"], name: "index_orders_on_user_location_id"
     t.index ["uuid"], name: "index_orders_on_uuid", unique: true
+  end
+
+  create_table "page_views", force: :cascade do |t|
+    t.bigint "session_id", null: false
+    t.string "page_path", null: false
+    t.string "query_params"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["page_path"], name: "index_page_views_on_page_path"
+    t.index ["session_id"], name: "index_page_views_on_session_id"
   end
 
   create_table "payment_events", force: :cascade do |t|
@@ -274,6 +284,7 @@ ActiveRecord::Schema.define(version: 2022_10_02_064845) do
   add_foreign_key "email_communications", "communications"
   add_foreign_key "orders", "payments"
   add_foreign_key "orders", "user_locations"
+  add_foreign_key "page_views", "sessions"
   add_foreign_key "payment_events", "payments"
   add_foreign_key "payments", "purchase_carts"
   add_foreign_key "payments", "users"

--- a/spec/actions/api/v1/page_views/creator_spec.rb
+++ b/spec/actions/api/v1/page_views/creator_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PageViews::Creator do
+  subject(:creator) do
+    described_class.new(session: session, params: { page_path: '/something', query_params: '?test=true' })
+  end
+
+  let(:session) { create(:session) }
+
+  describe '#call' do
+    subject(:result) { creator.call }
+
+    describe 'when successful' do
+      it 'creates a new page view' do
+        expect { result }.to change(PageView, :count).by(1)
+      end
+
+      it 'returns the created page view' do
+        expect(result.value!).to eq(PageView.last)
+      end
+    end
+
+    describe 'when page view could not be created' do
+      let(:session) { nil }
+
+      it 'fails' do
+        expect(result.failure?).to eq(true)
+      end
+
+      it 'returns an internal error code' do
+        expect(result.failure[:code]).to eq(:internal_error)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/page_views_controller_spec.rb
+++ b/spec/controllers/api/v1/page_views_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PageViewsController, type: :controller do
+  render_views
+
+  describe '#create' do
+    let(:session) { create(:session) }
+    let(:created_page_view) { create(:page_view, session: session) }
+    let(:creator_result) do
+      instance_double('Creator Result', success?: true, failure?: false, value!: created_page_view)
+    end
+    let(:creator) { instance_double(Api::V1::Sessions::Creator, call: creator_result) }
+
+    before do
+      allow(Api::V1::PageViews::Creator).to receive(:new).and_return creator
+
+      request.headers['X-SESSION-ID'] = session.uuid
+      request.headers['X-AUDIOPHILE-KEY'] = 'audiophile'
+
+      post :create, format: :json
+    end
+
+    it 'calls the sessions creator' do
+      expect(creator).to have_received(:call)
+    end
+
+    it 'returns a 204 status' do
+      expect(response.status).to eq 204
+    end
+
+    describe 'when creator fails due to internal error' do
+      let(:creator_result) do
+        instance_double('Creator Result', success?: false, failure?: true, failure: { code: :internal_error })
+      end
+
+      it 'returns a 500 status' do
+        expect(response.status).to eq 500
+      end
+    end
+  end
+end

--- a/spec/factories/page_view.rb
+++ b/spec/factories/page_view.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :page_view do
+    association :session
+
+    page_path { Faker::Internet.url }
+    query_params { Faker::Internet.slug }
+  end
+end

--- a/spec/models/page_view_spec.rb
+++ b/spec/models/page_view_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe PageView do
+  subject(:page_view) { build(:page_view) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:session) }
+  end
+end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Session, type: :model do
   describe 'associations' do
     it { is_expected.to have_many(:purchase_carts) }
     it { is_expected.to belong_to(:user).optional }
+    it { is_expected.to have_many(:page_views).dependent(:destroy) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
Closes #158
This PR builds a super simple system to save session page views. A new endpoint to record a new page_view, and a new table are both added. In mapra99/audiophile-fe#45 the frontend server will consume this endpoint on each visit.

I'll build a basic product recommendations system using the pageviews that are saved for all users