### PR TITLE
fix(purchase carts): ensure cart items are sorted by creation

### DIFF
--- a/app/models/purchase_cart_item.rb
+++ b/app/models/purchase_cart_item.rb
@@ -8,6 +8,8 @@ class PurchaseCartItem < ApplicationRecord
   validates :unit_price, presence: true
   validates :stock_id, uniqueness: { scope: :purchase_cart_id }
 
+  scope :sorted_by_creation, -> { order(:created_at) }
+
   def total_price
     (unit_price * quantity).to_f
   end

--- a/app/views/api/v1/purchase_carts/_purchase_cart.json.jbuilder
+++ b/app/views/api/v1/purchase_carts/_purchase_cart.json.jbuilder
@@ -2,7 +2,7 @@ json.uuid purchase_cart.uuid
 json.total_price purchase_cart.total_price
 json.status purchase_cart.status
 json.user_location_uuid purchase_cart.user_location&.uuid
-json.items purchase_cart.purchase_cart_items do |cart_item|
+json.items purchase_cart.purchase_cart_items.sorted_by_creation do |cart_item|
   json.partial! 'purchase_cart_item', purchase_cart_item: cart_item
 end
 

--- a/spec/models/purchase_cart_item_spec.rb
+++ b/spec/models/purchase_cart_item_spec.rb
@@ -45,4 +45,17 @@ RSpec.describe PurchaseCartItem, type: :model do
       expect(stock.quantity).to eq(7)
     end
   end
+
+  describe '.sorted_by_creation' do
+    subject(:items) { described_class.all.sorted_by_creation }
+
+    before do
+      create(:purchase_cart_item, created_at: 3.days.from_now)
+      create(:purchase_cart_item, created_at: 1.day.ago)
+    end
+
+    it 'is sorted by created_at' do
+      expect(items[0].created_at).to be < items[1].created_at
+    end
+  end
 end


### PR DESCRIPTION
Closes #164
The purchase cart endpoints should return the cart items ordered by creation timestamp so that they are always returned in the same order