### PR TITLE
feat(stocks): filter products by stock available

### DIFF
--- a/app/actions/api/v1/products/collection_builder.rb
+++ b/app/actions/api/v1/products/collection_builder.rb
@@ -23,6 +23,7 @@ module Api
           filter_by_category(filters[:category_ids]) if filters[:category_ids].present?
           filter_by_featured(filters[:featured]) if filters[:featured].present?
           filter_by_content(filters[:content]) if filters[:content].present?
+          filter_by_stock_available(filters[:stock_available]) if filters[:stock_available].present?
         end
 
         def filter_by_category(category_ids)
@@ -42,6 +43,12 @@ module Api
           end
 
           self.result = result.where(id: product_contents.pluck(:product_id))
+        end
+
+        def filter_by_stock_available(stock_available)
+          return unless stock_available == 'true'
+
+          self.result = result.with_available_stocks
         end
       end
     end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -22,7 +22,7 @@ module Api
       private
 
       def filter_params
-        params.permit(:featured, :categories, content: {})
+        params.permit(:featured, :stock_available, :categories, content: {})
       end
     end
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,6 +12,8 @@ class Product < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :base_price, presence: true
 
+  scope :with_available_stocks, -> { where(id: Stock.available.pluck(:product_id)) }
+
   def total_quantity
     stocks.pluck(:quantity).sum
   end

--- a/app/models/stock.rb
+++ b/app/models/stock.rb
@@ -8,6 +8,8 @@ class Stock < ApplicationRecord
 
   validates :quantity, presence: true
 
+  scope :available, -> { where('quantity > 0') }
+
   def self.filter_exactly_by_toppings(toppings)
     includes(:toppings).select do |stock|
       stock.toppings.pluck(:id).sort == toppings.pluck(:id).sort

--- a/app/views/api/v1/product_categories/_product_category.json.jbuilder
+++ b/app/views/api/v1/product_categories/_product_category.json.jbuilder
@@ -9,6 +9,6 @@ if product_category.image.attached?
   end
 end
 
-json.products product_category.products do |product|
+json.products product_category.products.with_available_stocks do |product|
   json.partial! 'product', product: product
 end

--- a/spec/actions/api/v1/products/collection_builder_spec.rb
+++ b/spec/actions/api/v1/products/collection_builder_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe Api::V1::Products::CollectionBuilder do
         expect(result.value!.count).to eq(1)
       end
     end
+
+    describe 'stock available filter' do
+      let(:result) { subject.call(filters: { stock_available: 'true' }) }
+
+      before do
+        create_list(:product, 2)
+        product = create(:product)
+        create(:stock, product: product, quantity: 1)
+      end
+
+      it 'succeeds' do
+        expect(result.success?).to eq true
+      end
+
+      it 'returns the only product with stocks available' do
+        expect(result.value!.count).to eq(1)
+      end
+    end
   end
 
   describe 'when an error is raised' do

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -29,4 +29,20 @@ RSpec.describe Product, type: :model do
       expect(product.total_quantity).to eq(25)
     end
   end
+
+  describe '.with_available_stocks' do
+    subject(:result) { described_class.with_available_stocks }
+
+    before do
+      available_stock = create(:stock, quantity: 10)
+      create(:product, stocks: [available_stock])
+
+      empty_stock = create(:stock, quantity: 0)
+      create(:product, stocks: [empty_stock])
+    end
+
+    it 'returns only the products with available stocks' do
+      expect(result.count).to eq(1)
+    end
+  end
 end

--- a/spec/models/stock_spec.rb
+++ b/spec/models/stock_spec.rb
@@ -47,4 +47,17 @@ RSpec.describe Stock, type: :model do
       expect(result).to eq(500.0)
     end
   end
+
+  describe '.available' do
+    subject(:result) { described_class.available }
+
+    before do
+      create(:stock, quantity: 10)
+      create(:stock, quantity: 0)
+    end
+
+    it 'returns only the stocks with existing quantity' do
+      expect(result.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Closes #166
The product endpoints are returning products with sold-out units (hence unavailable). This PR adds the ability to receive a query param on those ones to return only products with available units. Also the product categories endpoint should now return by default products with available units