### PR TITLE
fix(sessions): receive client ip as body param

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -19,7 +19,7 @@ module Api
       private
 
       def client_ip
-        request.remote_ip
+        params[:client_ip] || request.remote_ip
       end
 
       def error_status_code(error)


### PR DESCRIPTION
Closes #162 
When creating sessions I think I was capturing user IP addresses by looking at a default request header that is used for that per HTTP specs. However, since I'm consuming this API from the frontend server, I'm actually capturing the frontend server's IP address on each request. I'll be changing it by sending _manually_ on the body the user IP address in mapra99/audiophile-fe#48.