### PR TITLE
feat(products): build recommendations based on session pageviews

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,6 @@ Rails/UnknownEnv:
     - staging
     - test
     - development
+
+Style/RegexpLiteral:
+  Enabled: false

--- a/Dockerfile.sidekiq.staging
+++ b/Dockerfile.sidekiq.staging
@@ -23,4 +23,7 @@ RUN bundle install --no-cache
 # Copy the whole app
 COPY . /app
 
+# Schedule periodic jobs in crontab
+RUN bundle exec whenever --update-crontab
+
 CMD ["bundle", "exec", "sidekiq", "-C", "config/sidekiq.yml"]

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem 'aws-sdk-locationservice'
 # S3
 gem 'aws-sdk-s3'
 
+gem 'whenever', '~> 1.0.0'
+
 # Generate easily slugs for models https://github.com/norman/friendly_id
 gem 'friendly_id'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
@@ -300,6 +301,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     zeitwerk (2.6.0)
 
 PLATFORMS
@@ -341,6 +344,7 @@ DEPENDENCIES
   tzinfo-data
   vcr
   webmock
+  whenever (~> 1.0.0)
 
 RUBY VERSION
    ruby 3.0.4p208

--- a/app/jobs/recommendations/recommendations_builder_job.rb
+++ b/app/jobs/recommendations/recommendations_builder_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Recommendations
+  class RecommendationsBuilderJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      Product.all.each do |product|
+        Recommendations::RecommendationsBuilder.new(product_id: product.id).call
+      rescue StandardError => e
+        Rails.logger.error(e)
+      end
+    end
+  end
+end

--- a/app/models/page_view.rb
+++ b/app/models/page_view.rb
@@ -1,3 +1,20 @@
 class PageView < ApplicationRecord
   belongs_to :session
+  has_one :product_page_view, dependent: :destroy
+
+  PRODUCT_PAGES_PATH = /\/products\/([\w|-]+)/
+
+  after_create :create_product_page_view
+
+  private
+
+  def create_product_page_view
+    product_page = PRODUCT_PAGES_PATH.match(page_path)
+    return if product_page.blank?
+
+    slug = product_page.captures[0]
+    product = Product.find_by(slug: slug)
+
+    ProductPageView.create(page_view: self, product: product)
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,6 +7,10 @@ class Product < ApplicationRecord
   has_many :product_contents, dependent: :destroy
   has_many :stocks, dependent: :destroy
   has_many :toppings, dependent: :destroy
+  has_many :product_recommendations, dependent: :destroy
+  has_many :recommended_products, through: :product_recommendations, source: :recommendation
+  has_many :product_page_views, dependent: :nullify
+  has_many :page_views, through: :product_page_views
   belongs_to :product_category
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/product_page_view.rb
+++ b/app/models/product_page_view.rb
@@ -1,0 +1,4 @@
+class ProductPageView < ApplicationRecord
+  belongs_to :product
+  belongs_to :page_view
+end

--- a/app/models/product_recommendation.rb
+++ b/app/models/product_recommendation.rb
@@ -1,0 +1,4 @@
+class ProductRecommendation < ApplicationRecord
+  belongs_to :product
+  belongs_to :recommendation, class_name: 'Product'
+end

--- a/app/services/recommendations/recommendations_builder.rb
+++ b/app/services/recommendations/recommendations_builder.rb
@@ -1,0 +1,59 @@
+module Recommendations
+  class RecommendationsBuilder
+    attr_reader :product, :product_recommendations
+
+    RECOMMENDATIONS_PER_PRODUCT = 4
+
+    def initialize(product_id:)
+      self.product_id = product_id
+    end
+
+    def call
+      product = find_product
+      session_ids = find_sessions_that_viewed_product(product)
+      sessions_product_page_views = find_sessions_product_page_views(session_ids)
+      grouped_page_views = group_pageviews_by_product(sessions_product_page_views)
+
+      ActiveRecord::Base.transaction do
+        delete_previous_recommendations(product)
+        create_new_recommendations(product, grouped_page_views)
+      end
+
+      product_recommendations
+    end
+
+    private
+
+    attr_accessor :product_id
+    attr_writer :product_recommendations
+
+    def find_product
+      Product.find(product_id)
+    end
+
+    def find_sessions_that_viewed_product(product)
+      product_page_views = product.page_views
+      product_page_views.pluck(:session_id)
+    end
+
+    def find_sessions_product_page_views(session_ids)
+      page_views_ids = PageView.where(session_id: session_ids).pluck(:id)
+      ProductPageView.where(page_view_id: page_views_ids).where.not(product_id: product_id)
+    end
+
+    def group_pageviews_by_product(sessions_product_page_views)
+      sessions_product_page_views.group(:product_id).count
+    end
+
+    def delete_previous_recommendations(product)
+      product.product_recommendations.destroy_all
+    end
+
+    def create_new_recommendations(product, grouped_page_views)
+      recommended_product_ids = grouped_page_views.first(RECOMMENDATIONS_PER_PRODUCT).map { |p| p[0] }
+      self.product_recommendations = recommended_product_ids.map do |recommended_product_id|
+        product.product_recommendations.create!(recommendation_id: recommended_product_id)
+      end
+    end
+  end
+end

--- a/app/views/api/v1/products/_product.json.jbuilder
+++ b/app/views/api/v1/products/_product.json.jbuilder
@@ -28,3 +28,9 @@ json.toppings do
     json.set! key, toppings.pluck(:value)
   end
 end
+
+json.recommendations do
+  product.recommended_products.sample(3) do |recommended_product|
+    json.partial! 'recommended_product', product: recommended_product
+  end
+end

--- a/app/views/api/v1/products/_product.json.jbuilder
+++ b/app/views/api/v1/products/_product.json.jbuilder
@@ -30,7 +30,7 @@ json.toppings do
 end
 
 json.recommendations do
-  product.recommended_products.sample(3) do |recommended_product|
+  product.recommended_products do |recommended_product|
     json.partial! 'recommended_product', product: recommended_product
   end
 end

--- a/app/views/api/v1/products/_recommended_product.json.jbuilder
+++ b/app/views/api/v1/products/_recommended_product.json.jbuilder
@@ -1,0 +1,13 @@
+json.name product.name
+json.slug product.slug
+json.base_price product.base_price
+json.featured product.featured
+json.total_quantity product.total_quantity
+json.created_at product.created_at
+json.updated_at product.updated_at
+
+if product.image.attached?
+  json.image do
+    json.url product.image.url
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every :week do
+  runner 'Recommendations::RecommendationsBuilderJob.perform_later'
+end

--- a/db/migrate/20221226115546_create_product_recommendations.rb
+++ b/db/migrate/20221226115546_create_product_recommendations.rb
@@ -1,0 +1,10 @@
+class CreateProductRecommendations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :product_recommendations do |t|
+      t.references :product, null: false, foreign_key: true
+      t.references :recommendation, null: false, foreign_key: { to_table: :products }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221226125921_add_page_type_to_page_views.rb
+++ b/db/migrate/20221226125921_add_page_type_to_page_views.rb
@@ -1,0 +1,6 @@
+class AddPageTypeToPageViews < ActiveRecord::Migration[6.1]
+  def change
+    add_column :page_views, :page_type, :string
+    add_index :page_views, :page_type
+  end
+end

--- a/db/migrate/20221226130358_create_product_page_views.rb
+++ b/db/migrate/20221226130358_create_product_page_views.rb
@@ -1,0 +1,10 @@
+class CreateProductPageViews < ActiveRecord::Migration[6.1]
+  def change
+    create_table :product_page_views do |t|
+      t.references :product, null: false, foreign_key: true
+      t.references :page_view, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_22_024311) do
+ActiveRecord::Schema.define(version: 2022_12_26_130358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,7 +108,9 @@ ActiveRecord::Schema.define(version: 2022_12_22_024311) do
     t.string "query_params"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "page_type"
     t.index ["page_path"], name: "index_page_views_on_page_path"
+    t.index ["page_type"], name: "index_page_views_on_page_type"
     t.index ["session_id"], name: "index_page_views_on_session_id"
   end
 
@@ -151,6 +153,24 @@ ActiveRecord::Schema.define(version: 2022_12_22_024311) do
     t.index ["key", "product_id"], name: "index_product_contents_on_key_and_product_id", unique: true
     t.index ["key"], name: "index_product_contents_on_key"
     t.index ["product_id"], name: "index_product_contents_on_product_id"
+  end
+
+  create_table "product_page_views", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.bigint "page_view_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["page_view_id"], name: "index_product_page_views_on_page_view_id"
+    t.index ["product_id"], name: "index_product_page_views_on_product_id"
+  end
+
+  create_table "product_recommendations", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.bigint "recommendation_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["product_id"], name: "index_product_recommendations_on_product_id"
+    t.index ["recommendation_id"], name: "index_product_recommendations_on_recommendation_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -289,6 +309,10 @@ ActiveRecord::Schema.define(version: 2022_12_22_024311) do
   add_foreign_key "payments", "purchase_carts"
   add_foreign_key "payments", "users"
   add_foreign_key "product_contents", "products"
+  add_foreign_key "product_page_views", "page_views"
+  add_foreign_key "product_page_views", "products"
+  add_foreign_key "product_recommendations", "products"
+  add_foreign_key "product_recommendations", "products", column: "recommendation_id"
   add_foreign_key "products", "product_categories"
   add_foreign_key "purchase_cart_extra_fees", "purchase_carts"
   add_foreign_key "purchase_cart_items", "purchase_carts"

--- a/spec/factories/product_page_view.rb
+++ b/spec/factories/product_page_view.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :product_page_view do
+    association :product
+    association :page_view
+  end
+end

--- a/spec/factories/product_recommendation.rb
+++ b/spec/factories/product_recommendation.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :product_recommendation do
+    association :product
+    association :recommendation, factory: :product
+  end
+end

--- a/spec/jobs/recommendations/recommendations_builder_job_spec.rb
+++ b/spec/jobs/recommendations/recommendations_builder_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Recommendations::RecommendationsBuilderJob, type: :job do
+  let(:recommendations_builder) { instance_double(Recommendations::RecommendationsBuilder, call: true) }
+
+  before do
+    allow(Recommendations::RecommendationsBuilder).to receive(:new).and_return(recommendations_builder)
+    create_list(:product, 10)
+
+    described_class.perform_now
+  end
+
+  it 'calls the recommendation builder service once per product' do
+    expect(recommendations_builder).to have_received(:call).exactly(10)
+  end
+end

--- a/spec/models/page_view_spec.rb
+++ b/spec/models/page_view_spec.rb
@@ -5,5 +5,34 @@ RSpec.describe PageView do
 
   describe 'associations' do
     it { is_expected.to belong_to(:session) }
+    it { is_expected.to have_one(:product_page_view) }
+  end
+
+  describe '#create_product_page_view hook' do
+    before do
+      page_view.save
+    end
+
+    describe 'when page path is a product page' do
+      subject(:page_view) { build(:page_view, page_path: "/products/#{product.slug}") }
+
+      let(:product) { create(:product) }
+
+      it 'creates a product page view record' do
+        expect(page_view.product_page_view).not_to be_nil
+      end
+
+      it 'gets asociated with the product' do
+        expect(page_view.product_page_view.product).to eq(product)
+      end
+    end
+
+    describe 'when page path is not a product page' do
+      subject(:page_view) { build(:page_view, page_path: '/') }
+
+      it 'does not create a product page view' do
+        expect(page_view.product_page_view).to be_nil
+      end
+    end
   end
 end

--- a/spec/models/product_page_view_spec.rb
+++ b/spec/models/product_page_view_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ProductPageView, type: :model do
+  subject(:product_page_view) { build(:product_page_view) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:product) }
+    it { is_expected.to belong_to(:page_view) }
+  end
+end

--- a/spec/models/product_recommendation_spec.rb
+++ b/spec/models/product_recommendation_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ProductRecommendation, type: :model do
+  subject(:recommendation) { build(:product_recommendation) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:product) }
+    it { is_expected.to belong_to(:recommendation) }
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Product, type: :model do
     it { is_expected.to belong_to(:product_category) }
     it { is_expected.to have_many(:stocks) }
     it { is_expected.to have_many(:toppings) }
+    it { is_expected.to have_many(:product_recommendations) }
+    it { is_expected.to have_many(:recommended_products).through(:product_recommendations) }
+    it { is_expected.to have_many(:product_page_views).dependent(:nullify) }
+    it { is_expected.to have_many(:page_views).through(:product_page_views) }
   end
 
   describe 'validations' do

--- a/spec/services/recommendations/recommendations_builder_spec.rb
+++ b/spec/services/recommendations/recommendations_builder_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Recommendations::RecommendationsBuilder do
+  subject(:builder) { described_class.new(product_id: product_id) }
+
+  let(:product) { create(:product) }
+  let(:product_id) { product.id }
+
+  describe '#call' do
+    subject(:product_recommendations) { builder.product_recommendations }
+
+    let(:recommended_product) { create(:product) }
+
+    before do
+      session = create(:session)
+      create(:page_view, page_path: "/products/#{product.slug}", session: session)
+      create(:page_view, page_path: "/products/#{recommended_product.slug}", session: session)
+
+      builder.call
+    end
+
+    it 'returns the recommended product based on all sessions that also saw the target product' do
+      expect(product_recommendations.first.recommendation).to eq(recommended_product)
+    end
+  end
+end


### PR DESCRIPTION
Closes #160 

A recommendations system is built based on session pageviews. For each product, it will look up on the DB for all the sessions that visited the same product and will recommend other products based on all the pageviews of other products made by these sessions.

I added a new `product_page_views` table that will be 1:1 associated with `page_views` and `1:N` associated with `products`.  I'm just using it to distinguish all generic pageviews and pageviews specific for product pages. So, whenever a user visits a product page, both a `page_view` and `product_page_view` will be created

The result will be stored on the DB in a new `product_recommendations` table, and it will be returned to the frontend in the products endpoints response.

There will be a background job that will compute the recommendations for all the products. This job will run weekly, I added the `whenever` gem to configure these periodic jobs. After running a command, the gem will read this configuration and will make them run periodically as expected using crontab.