### PR TITLE
chore(build): run db migrations during app deploy

### DIFF
--- a/fly.api.staging.toml
+++ b/fly.api.staging.toml
@@ -39,3 +39,6 @@ processes = []
     interval = "15s"
     restart_limit = 0
     timeout = "2s"
+
+[deploy]
+  release_command = "bundle exec rails db:migrate"

--- a/fly.sidekiq.staging.toml
+++ b/fly.sidekiq.staging.toml
@@ -13,3 +13,6 @@ processes = []
 [experimental]
   allowed_public_ports = []
   auto_rollback = true
+
+[deploy]
+  release_command = "bundle exec rails db:migrate"


### PR DESCRIPTION
Closes #173 
Just a minor change to automate the `rails db:migrate` task execution after each build