### PR TITLE
feat(purchase carts): allow all actions scoped by either user or session

### DIFF
--- a/app/actions/api/v1/purchase_carts/collection_builder.rb
+++ b/app/actions/api/v1/purchase_carts/collection_builder.rb
@@ -4,13 +4,13 @@ module Api
       class CollectionBuilder
         include Dry::Monads[:result]
 
-        def initialize(session:, filters: {})
-          self.session = session
+        def initialize(owner:, filters: {})
+          self.owner = owner
           self.filters = filters
         end
 
         def call
-          self.result = session.purchase_carts
+          self.result = owner.purchase_carts
           self.result = filter_by_status
 
           Success(result)
@@ -23,7 +23,7 @@ module Api
 
         private
 
-        attr_accessor :result, :session, :filters
+        attr_accessor :result, :owner, :filters
 
         def filter_by_status
           return result if filters[:status].blank?

--- a/app/actions/api/v1/purchase_carts/creator.rb
+++ b/app/actions/api/v1/purchase_carts/creator.rb
@@ -6,9 +6,9 @@ module Api
 
         attr_reader :params, :purchase_cart
 
-        def initialize(params:, session:)
+        def initialize(params:, owner:)
           self.params = params
-          self.session = session
+          self.owner = owner
         end
 
         def call
@@ -29,10 +29,10 @@ module Api
         private
 
         attr_writer :params, :purchase_cart
-        attr_accessor :session
+        attr_accessor :owner
 
         def create_cart
-          self.purchase_cart = session.purchase_carts.create(
+          self.purchase_cart = owner.purchase_carts.create(
             status: PurchaseCart::STARTED,
             total_price: 0
           )

--- a/app/actions/api/v1/purchase_carts/destroyer.rb
+++ b/app/actions/api/v1/purchase_carts/destroyer.rb
@@ -4,9 +4,9 @@ module Api
       class Destroyer
         include Dry::Monads[:result]
 
-        def initialize(cart_uuid:, session:)
+        def initialize(cart_uuid:, owner:)
           self.cart_uuid = cart_uuid
-          self.session = session
+          self.owner = owner
         end
 
         def call
@@ -21,10 +21,10 @@ module Api
 
         private
 
-        attr_accessor :cart_uuid, :session
+        attr_accessor :cart_uuid, :owner
 
         def cancel_cart
-          Purchases::CartCanceler.new(cart_uuid: cart_uuid, session: session).call
+          Purchases::CartCanceler.new(cart_uuid: cart_uuid, owner: owner).call
         rescue Purchases::CartNotFound => e
           raise ServiceError, Failure({ code: :cart_not_found, message: e.message })
         rescue Purchases::InvalidStatusForCancelation => e

--- a/app/actions/api/v1/purchase_carts/finder.rb
+++ b/app/actions/api/v1/purchase_carts/finder.rb
@@ -6,13 +6,13 @@ module Api
 
         attr_reader :cart
 
-        def initialize(cart_uuid:, session:)
+        def initialize(cart_uuid:, owner:)
           self.cart_uuid = cart_uuid
-          self.session = session
+          self.owner = owner
         end
 
         def call
-          result = session.purchase_carts.find_by!(uuid: cart_uuid)
+          result = owner.purchase_carts.find_by!(uuid: cart_uuid)
 
           self.cart = result
           Success(result)
@@ -23,7 +23,7 @@ module Api
 
         private
 
-        attr_accessor :cart_uuid, :session
+        attr_accessor :cart_uuid, :owner
         attr_writer :cart
       end
     end

--- a/app/actions/api/v1/purchase_carts/updater.rb
+++ b/app/actions/api/v1/purchase_carts/updater.rb
@@ -6,9 +6,9 @@ module Api
 
         attr_reader :params, :purchase_cart
 
-        def initialize(params:, session:)
+        def initialize(params:, owner:)
           self.params = params
-          self.session = session
+          self.owner = owner
         end
 
         def call
@@ -28,10 +28,10 @@ module Api
         private
 
         attr_writer :params, :purchase_cart
-        attr_accessor :session
+        attr_accessor :owner
 
         def find_cart
-          self.purchase_cart = session.purchase_carts.find_by!(uuid: params[:uuid])
+          self.purchase_cart = owner.purchase_carts.find_by!(uuid: params[:uuid])
         rescue ActiveRecord::RecordNotFound => e
           raise ServiceError, Failure({ code: :cart_not_found, message: e.message })
         end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,8 +1,7 @@
 module Api
   module V1
     class BaseController < Api::BaseController
-      include TokenAuth
-      include SessionAuth
+      include GlobalAuth
 
       before_action :validate_api_key!
 

--- a/app/controllers/concerns/global_auth.rb
+++ b/app/controllers/concerns/global_auth.rb
@@ -1,0 +1,14 @@
+module GlobalAuth
+  extend ActiveSupport::Concern
+
+  include SessionAuth
+  include TokenAuth
+
+  included do
+    before_action :authenticate_user_by_token!
+  end
+
+  def authenticate_session_or_user!
+    return head :unauthorized if current_user.blank? && current_session.blank?
+  end
+end

--- a/app/controllers/concerns/token_auth.rb
+++ b/app/controllers/concerns/token_auth.rb
@@ -1,12 +1,4 @@
 module TokenAuth
-  extend ActiveSupport::Concern
-
-  included do
-    before_action :authenticate_user_by_token!
-  end
-
-  private
-
   def authenticate_user_by_token!
     return head :unauthorized if current_user.blank?
   end

--- a/app/services/purchases/cart_canceler.rb
+++ b/app/services/purchases/cart_canceler.rb
@@ -4,9 +4,9 @@ module Purchases
       PurchaseCart::PAID
     ].freeze
 
-    def initialize(cart_uuid:, session:)
+    def initialize(cart_uuid:, owner:)
       self.cart_uuid = cart_uuid
-      self.session = session
+      self.owner = owner
     end
 
     def call
@@ -17,10 +17,10 @@ module Purchases
 
     private
 
-    attr_accessor :cart_uuid, :cart, :session
+    attr_accessor :cart_uuid, :cart, :owner
 
     def find_cart
-      self.cart = session.purchase_carts.find_by(uuid: cart_uuid)
+      self.cart = owner.purchase_carts.find_by(uuid: cart_uuid)
       raise CartNotFound, cart_uuid if cart.blank?
     end
 

--- a/spec/actions/api/v1/purchase_carts/collection_builder_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/collection_builder_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PurchaseCarts::CollectionBuilder do
-  subject(:builder) { described_class.new(session: session) }
+  subject(:builder) { described_class.new(owner: owner) }
 
+  let(:owner) { session }
   let(:session) { create(:session) }
 
   describe '#call' do
@@ -33,6 +34,23 @@ RSpec.describe Api::V1::PurchaseCarts::CollectionBuilder do
 
       it 'returns internal_error as failure code' do
         expect(result.failure[:code]).to eq(:internal_error)
+      end
+    end
+
+    describe 'when owner is user' do
+      let(:owner) { user }
+      let(:user) { create(:user) }
+
+      before do
+        create_list(:purchase_cart, 5, user: user, status: [PurchaseCart::PAID, PurchaseCart::CANCELED].sample)
+      end
+
+      it 'succeeds' do
+        expect(result.success?).to eq(true)
+      end
+
+      it 'returns an array with the purchse carts that belong to the session' do
+        expect(result.value!.count).to eq(5)
       end
     end
   end

--- a/spec/actions/api/v1/purchase_carts/creator_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/creator_spec.rb
@@ -125,16 +125,16 @@ RSpec.describe Api::V1::PurchaseCarts::Creator do
       it 'succeeds' do
         expect(result.success?).to eq(true)
       end
-  
+
       it 'creates a new cart' do
         expect { creator.call }.to change(PurchaseCart, :count).by(1)
       end
-  
+
       it 'calls the item generator service once per item' do
         creator.call
         expect(cart_item_generator).to have_received(:call).exactly(2)
       end
-  
+
       it 'calls the extra fees generator service' do
         creator.call
         expect(extra_fees_generator).to have_received(:call).exactly(1)

--- a/spec/actions/api/v1/purchase_carts/destroyer_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/destroyer_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Api::V1::PurchaseCarts::Destroyer do
       it 'succeeds' do
         expect(result.success?).to eq(true)
       end
-  
+
       it 'calls the cart canceler' do
         expect(cart_canceler).to have_received(:call)
       end

--- a/spec/actions/api/v1/purchase_carts/destroyer_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/destroyer_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PurchaseCarts::Destroyer do
-  subject(:destroyer) { described_class.new(cart_uuid: cart_uuid, session: session) }
+  subject(:destroyer) { described_class.new(cart_uuid: cart_uuid, owner: session) }
 
+  let(:owner) { session }
   let(:session) { create(:session) }
   let(:cart) { create(:purchase_cart, session: session) }
   let(:cart_uuid) { cart.uuid }
@@ -65,6 +66,19 @@ RSpec.describe Api::V1::PurchaseCarts::Destroyer do
 
       it 'returns the right error code' do
         expect(result.failure[:code]).to eq(:invalid_status)
+      end
+    end
+
+    describe 'when owner is user' do
+      let(:owner) { user }
+      let(:user) { create(:user) }
+
+      it 'succeeds' do
+        expect(result.success?).to eq(true)
+      end
+  
+      it 'calls the cart canceler' do
+        expect(cart_canceler).to have_received(:call)
       end
     end
   end

--- a/spec/actions/api/v1/purchase_carts/finder_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/finder_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PurchaseCarts::Finder do
-  subject(:finder) { described_class.new(cart_uuid: cart_uuid, session: session) }
+  subject(:finder) { described_class.new(cart_uuid: cart_uuid, owner: owner) }
 
+  let(:owner) { session }
   let(:session) { create(:session) }
   let(:cart) { create(:purchase_cart, session: session) }
   let(:cart_uuid) { cart.uuid }
@@ -29,6 +30,20 @@ RSpec.describe Api::V1::PurchaseCarts::Finder do
 
       it 'returns the right error code' do
         expect(result.failure[:code]).to eq(:cart_not_found)
+      end
+    end
+
+    describe 'when owner is user' do
+      let(:owner) { user }
+      let(:user) { create(:user) }
+      let(:cart) { create(:purchase_cart, user: user) }
+
+      it 'succeeds' do
+        expect(result.success?).to eq(true)
+      end
+
+      it 'returns the cart record' do
+        expect(result.value!).to eq(cart)
       end
     end
   end

--- a/spec/actions/api/v1/purchase_carts/updater_spec.rb
+++ b/spec/actions/api/v1/purchase_carts/updater_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::PurchaseCarts::Updater do
-  subject(:updater) { described_class.new(params: params, session: session) }
+  subject(:updater) { described_class.new(params: params, owner: owner) }
 
+  let(:owner) { session }
   let(:session) { create(:session) }
   let(:purchase_cart) { create(:purchase_cart, session: session, user_location: nil) }
   let(:user_location) do
@@ -53,6 +54,22 @@ RSpec.describe Api::V1::PurchaseCarts::Updater do
 
       it 'returns the right error code' do
         expect(result.failure[:code]).to eq(:cart_not_found)
+      end
+    end
+
+    describe 'when owner is user' do
+      let(:owner) { user }
+      let(:user) { create(:user) }
+      let(:purchase_cart) { create(:purchase_cart, user: user, user_location: nil) }
+
+      it 'succeeds' do
+        expect(result.success?).to eq(true)
+      end
+
+      it 'updates the cart user_location' do
+        updater.call
+
+        expect(purchase_cart.reload.user_location).to eq(user_location)
       end
     end
   end

--- a/spec/services/purchases/cart_canceler_spec.rb
+++ b/spec/services/purchases/cart_canceler_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Purchases::CartCanceler do
-  subject(:canceler) { described_class.new(cart_uuid: cart_uuid, session: session) }
+  subject(:canceler) { described_class.new(cart_uuid: cart_uuid, owner: owner) }
 
+  let(:owner) { session }
   let(:session) { create(:session) }
   let(:cart) { create(:purchase_cart, status: cart_status, session: session) }
   let(:cart_uuid) { cart.uuid }
@@ -32,6 +33,20 @@ RSpec.describe Purchases::CartCanceler do
 
       it 'raises an error' do
         expect { canceler.call }.to raise_error(Purchases::InvalidStatusForCancelation)
+      end
+    end
+
+    describe 'when owner is user' do
+      let(:owner) { user }
+      let(:user) { create(:user) }
+      let(:cart) { create(:purchase_cart, status: cart_status, user: user) }
+
+      before do
+        canceler.call
+      end
+
+      it 'updates the cart status to canceled' do
+        expect(cart.reload.status).to eq(PurchaseCart::CANCELED)
       end
     end
   end


### PR DESCRIPTION
Closes #178 
Currently, all the endpoints for the purchase carts resource need authentication by session header, and all the operations internally are scoped to the authenticated session. We really need to make these operations polymorphic, so they can be performed either within the scope of a session or an actual user

I'm changing the authentication check on the purchase carts controller to authenticate by `current_user` or `current_session`. Then, I'm changing all the action classes to receive an `owner` attribute, which would be either a session or a user. Now `owner` is a little duck, it can be any object that has many purchase carts