### PR TITLE
chore(dockerfile): install bash in sidekiq instance

### DIFF
--- a/Dockerfile.sidekiq.staging
+++ b/Dockerfile.sidekiq.staging
@@ -2,7 +2,7 @@
 FROM ruby:3.0.4-alpine
 
 # install rails dependencies
-RUN apk add --update --no-cache build-base libpq-dev
+RUN apk add --update --no-cache build-base libpq-dev bash
 
 # create a folder /app in the docker container and go into that folder
 RUN mkdir /app


### PR DESCRIPTION
Closes #184

While looking at how the recommendations job has been behaving on staging, it was supposed to be running automatically each week, but it hasn't.

I'm using the `whenever` gem to configure periodic jobs. The gem basically reads a ruby configuration file that we have on the repository, and it just edits the crontab file in the system to have these jobs running on the frequency we want. The issue is that, for the recommendations job, I saw it adds this to the crontab file:
```
0 0 1,8,15,22 * * /bin/bash -l -c 'cd /app && bundle exec bin/rails runner -e production '\''Recommendations::RecommendationsBuilderJob.perform_later'\'''
```

I tried to run that command manually on the terminal in staging, and it failed because `/bin/bash` is not defined. It looks like alpine linux, which is the OS that we are using on the container, doesn't come with bash included. So I just added it to the Dockerfile to install it during the build.

I also tried to see if there is a way to have `whenever` using `/bin/sh` instead of `/bin/bash` but didn't find anything. So installing bash should fix the issue.