### PR TITLE
feat(sessions): remove old sessions periodically

### DIFF
--- a/app/jobs/sessions/old_sessions_remover_job.rb
+++ b/app/jobs/sessions/old_sessions_remover_job.rb
@@ -5,7 +5,7 @@ module Sessions
     queue_as :default
 
     def perform
-      OldSessionsRemover.new.call
+      Sessions::OldSessionsRemover.new.call
     end
   end
 end

--- a/app/jobs/sessions/old_sessions_remover_job.rb
+++ b/app/jobs/sessions/old_sessions_remover_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sessions
+  class OldSessionsRemoverJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      OldSessionsRemover.new.call
+    end
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -6,4 +6,7 @@ class Session < ApplicationRecord
   belongs_to :user, optional: true
   has_many :purchase_carts, dependent: :destroy
   has_many :page_views, dependent: :destroy
+
+  scope :more_than_one_month_old, -> { where('updated_at < ?', 1.month.ago) }
+  scope :with_no_purchase_carts, -> { where.not(id: PurchaseCart.all.pluck(:session_id)) }
 end

--- a/app/services/sessions/old_sessions_remover.rb
+++ b/app/services/sessions/old_sessions_remover.rb
@@ -1,0 +1,11 @@
+module Sessions
+  class OldSessionsRemover
+    def call
+      deletable_sessions = Session
+                           .more_than_one_month_old
+                           .with_no_purchase_carts
+
+      deletable_sessions.destroy_all
+    end
+  end
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,3 +22,7 @@
 every :week do
   runner 'Recommendations::RecommendationsBuilderJob.perform_later'
 end
+
+every :month do
+  runner 'Sessions::OldSessionsRemoverJob.perform_later'
+end

--- a/spec/jobs/sessions/old_sessions_remover_job_spec.rb
+++ b/spec/jobs/sessions/old_sessions_remover_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Sessions::OldSessionsRemoverJob, type: :job do
+  let(:sessions_remover) { instance_double(Sessions::OldSessionsRemover, call: true) }
+
+  before do
+    allow(Sessions::OldSessionsRemover).to receive(:new).and_return(sessions_remover)
+    described_class.perform_now
+  end
+
+  it 'calls the sessions remover once' do
+    expect(sessions_remover).to have_received(:call).once
+  end
+end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -12,4 +12,33 @@ RSpec.describe Session, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:ip_address) }
   end
+
+  describe '.more_than_one_month_old' do
+    subject(:result) { described_class.more_than_one_month_old }
+
+    let(:old_sessions) { create_list(:session, 2, updated_at: 5.months.ago) }
+
+    before do
+      old_sessions
+      create_list(:session, 2)
+    end
+
+    it 'returns all old sessions' do
+      expect(result).to eq(old_sessions)
+    end
+  end
+
+  describe '.with_no_purchase_carts' do
+    subject(:result) { described_class.with_no_purchase_carts }
+
+    let(:sessions) { create_list(:session, 3) }
+
+    before do
+      create(:purchase_cart, session: sessions.last)
+    end
+
+    it 'returns the sessions without purchase cart' do
+      expect(result).to eq(sessions[0..1])
+    end
+  end
 end

--- a/spec/services/sessions/old_sessions_remover_spec.rb
+++ b/spec/services/sessions/old_sessions_remover_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Sessions::OldSessionsRemover do
+  subject(:remover) { described_class.new }
+
+  describe '#call' do
+    before do
+      create_list(:session, 2, updated_at: 2.months.ago)
+      create_list(:session, 4)
+    end
+
+    it 'removes old sessions' do
+      expect { remover.call }.to change(Session, :count).from(6).to(4)
+    end
+
+    describe 'when old sessions have purchase carts' do
+      before do
+        session = create(:session, updated_at: 2.months.ago)
+        create(:purchase_cart, session: session)
+      end
+
+      it 'does not remove those' do
+        expect { remover.call }.to change(Session, :count).from(7).to(5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #176 

The sessions table has been getting bigger and bigger easily. This PR implements a scheduled job that would run every month to remove old sessions that don't have a purchase cart.