### PR TITLE
chore(env): add env file example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+ADMIN_HTTP_PASSWORD=pass1
+ADMIN_HTTP_USERNAME=audiophile-admin
+HOST_URL=http://localhost:3001/
+PORT=3001
+REDIS_URL=redis://localhost:6379
+X_ADMIN_KEY=admin
+X_AUDIOPHILE_KEY=audiophile
+
+# Use these vars if you need to provide more granular details/credentials to connect to your postgres instance
+POSTGRESQL_DB=
+POSTGRESQL_HOST=
+POSTGRESQL_PASSWORD=
+POSTGRESQL_USER_NAME=
+
+# Use these vars if you need to provide credentials to connect to your redis instance
+REDIS_USERNAME=
+REDIS_PASSWORD=
+
+# AWS Region. Must be the same for all services created
+AWS_REGION=
+
+# Create IAM credentials to be able to manage a S3 Bucket for image storage
+AWS_STORAGE_ACCESS_KEY_ID=
+AWS_STORAGE_SECRET_ACCESS_KEY=
+S3_BUCKET_NAME=
+
+# Sign up for AWS Location Service and create IAM credentials to play with it
+AWS_GEOCODE_ACCESS_KEY_ID=
+AWS_GEOCODE_SECRET_ACCESS_KEY=
+
+# Sign up at SendGrid https://signup.sendgrid.com/ and create an API Key for free
+SENDGRID_API_KEY=
+
+# Sign up at Stripe https://dashboard.stripe.com/register and create an account in dev mode for free
+STRIPE_API_SECRET_KEY=

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -9,8 +9,8 @@ local:
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
   service: S3
-  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
-  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+  access_key_id: <%= ENV["AWS_STORAGE_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["AWS_STORAGE_SECRET_ACCESS_KEY"] %>
   region: us-east-1
   bucket: <%= ENV["S3_BUCKET_NAME"] %>
 


### PR DESCRIPTION
I'm adding a `.env.example` file with some defaults for the env values to be used locally and some instructions for the ones that require some configuration/sign-up from vendors.